### PR TITLE
feat: switch routing to osrm

### DIFF
--- a/map-platform-backend/README.md
+++ b/map-platform-backend/README.md
@@ -22,8 +22,7 @@ Create a `.env` file in the root directory with the following variables:
 - `CORS_ORIGIN`: Allowed CORS origins
 
 **Optional:**
-- `MAPBOX_ACCESS_TOKEN`: For Mapbox integration
-- `GRAPHHOPPER_API_KEY`: For GraphHopper routing
+- `OSRM_HOST`: Custom OSRM server (defaults to router.project-osrm.org)
 - `CLOUDINARY_*`: For Cloudinary file uploads
 
 ### 3. MongoDB Setup
@@ -59,7 +58,7 @@ npm start
 - `POST /api/projects` - Create project
 - `GET /api/projects/:id/places` - List places in project
 - `POST /api/upload` - File upload
-- `POST /api/route` - Route calculation
+- `GET /api/route` - Route calculation
 
 ## Troubleshooting
 

--- a/map-platform-backend/env-config.txt
+++ b/map-platform-backend/env-config.txt
@@ -8,15 +8,10 @@ MONGODB_URI=mongodb://localhost:27017/map-platform
 PORT=4000
 CORS_ORIGIN=http://localhost:3000
 
-# Mapbox Configuration (optional)
-MAPBOX_ACCESS_TOKEN=your_mapbox_access_token_here
-MAPBOX_PROFILE=driving
-
-# GraphHopper Configuration (optional)
-GRAPHHOPPER_BASE_URL=https://graphhopper.com/api/1
-GRAPHHOPPER_API_KEY=your_graphhopper_api_key_here
+# Routing Configuration (optional)
+OSRM_HOST=https://router.project-osrm.org
 
 # Cloudinary Configuration (optional)
 CLOUDINARY_CLOUD_NAME=your_cloudinary_cloud_name
 CLOUDINARY_API_KEY=your_cloudinary_api_key
-CLOUDINARY_API_SECRET=your_cloudinary_api_secret 
+CLOUDINARY_API_SECRET=your_cloudinary_api_secret

--- a/map-platform-backend/src/controllers/route.controller.js
+++ b/map-platform-backend/src/controllers/route.controller.js
@@ -2,57 +2,34 @@ import axios from 'axios';
 import polyline from 'polyline';
 import { Project } from '../models/Project.js';
 
-const useMapbox = !!process.env.MAPBOX_ACCESS_TOKEN;
+const OSRM_HOST = process.env.OSRM_HOST || 'https://router.project-osrm.org';
 
-async function fetchRouteMapbox({ from, to }) {
-  const token = process.env.MAPBOX_ACCESS_TOKEN;
-  const profile = process.env.MAPBOX_PROFILE || 'driving';
-  const url = `https://api.mapbox.com/directions/v5/mapbox/${profile}/${from.lng},${from.lat};${to.lng},${to.lat}`;
+async function fetchRouteOSRM({ from, to, profile = 'driving' }) {
+  const coords = `${from.lng},${from.lat};${to.lng},${to.lat}`;
+  const url = `${OSRM_HOST}/route/v1/${profile}/${coords}`;
   const { data } = await axios.get(url, {
-    params: { access_token: token, geometries: 'polyline', overview: 'full' }
+    params: {
+      overview: 'full',
+      geometries: 'geojson',
+      steps: false,
+      alternatives: false
+    }
   });
   const route = data?.routes?.[0];
   if (!route) throw new Error('NoRoute');
-  return {
-    distance: route.distance, // meters
-    duration: route.duration, // seconds
-    encoded: route.geometry
-  };
-}
-
-async function fetchRouteGraphHopper({ from, to }) {
-  const base = process.env.GRAPHHOPPER_BASE_URL;
-  const key = process.env.GRAPHHOPPER_API_KEY;
-  if (!base || !key) throw new Error('GraphHopperNotConfigured');
-  const { data } = await axios.get(`${base}/route`, {
-    params: {
-      point: [`${from.lat},${from.lng}`, `${to.lat},${to.lng}`],
-      key,
-      profile: 'car',
-      points_encoded: true
-    },
-    paramsSerializer: p => new URLSearchParams(p).toString()
-  });
-  const path = data?.paths?.[0];
-  if (!path) throw new Error('NoRoute');
-  return {
-    distance: path.distance,
-    duration: path.time / 1000,
-    encoded: path.points
-  };
+  const encoded = polyline.encode(route.geometry.coordinates.map(([lng, lat]) => [lat, lng]));
+  return { distance: route.distance, duration: route.duration, encoded };
 }
 
 export const getRoute = async (req, res) => {
   const [fromLat, fromLng] = (req.query.from || '').split(',').map(Number);
   const [toLat, toLng] = (req.query.to || '').split(',').map(Number);
+  const profile = req.query.profile || 'driving';
   if (!fromLat || !fromLng || !toLat || !toLng) {
     return res.status(400).json({ error: 'InvalidCoordinates' });
   }
-
-  const args = { from: { lat: fromLat, lng: fromLng }, to: { lat: toLat, lng: toLng } };
-
   try {
-    const r = useMapbox ? await fetchRouteMapbox(args) : await fetchRouteGraphHopper(args);
+    const r = await fetchRouteOSRM({ from: { lat: fromLat, lng: fromLng }, to: { lat: toLat, lng: toLng }, profile });
     return res.json(r);
   } catch (e) {
     console.error('Route error:', e.message);
@@ -72,16 +49,13 @@ export const computeAndAttachRouteToSecondary = async (req, res) => {
   const to = { lat: secondary.latitude, lng: secondary.longitude };
 
   try {
-    const r = useMapbox ? await fetchRouteMapbox({ from, to }) : await fetchRouteGraphHopper({ from, to });
-    // human-friendly values
+    const profile = req.query.profile || 'driving';
+    const r = await fetchRouteOSRM({ from, to, profile });
     const km = (r.distance / 1000).toFixed(1) + ' KM';
     const mins = Math.round(r.duration / 60) + ' mins';
-
-    // attach
     secondary.routesFromBase = [r.encoded];
     secondary.footerInfo = { ...(secondary.footerInfo || {}), distance: km, time: mins };
     await project.save();
-
     return res.json({
       encoded: r.encoded,
       distance_m: r.distance,

--- a/map-platform-backend/src/index.js
+++ b/map-platform-backend/src/index.js
@@ -36,10 +36,7 @@ app.get('/health', (req, res) => res.json({ ok: true, time: new Date().toISOStri
 
 // Routes
 app.use('/api/projects', projectRoutes);
-app.use('/api/projects/:id/places', (req, res, next) => {
-  req.params.projectId = req.params.id; // normalize
-  next();
-}, placeRoutes);
+app.use('/api/projects/:projectId/places', placeRoutes);
 app.use('/api/upload', uploadRoutes);
 app.use('/api/route', routeRoutes);
 

--- a/map-platform-backend/src/routes/route.routes.js
+++ b/map-platform-backend/src/routes/route.routes.js
@@ -3,7 +3,7 @@ import { asyncHandler } from '../middlewares/asyncHandler.js';
 import { getRoute } from '../controllers/route.controller.js';
 
 const router = Router();
-// GET /api/route?from=lat,lng&to=lat,lng
+// GET /api/route?from=lat,lng&to=lat,lng&profile=driving
 router.get('/', asyncHandler(getRoute));
 
 export default router;

--- a/map-platform-frontend/README.md
+++ b/map-platform-frontend/README.md
@@ -8,7 +8,7 @@ A modern React/Next.js frontend for the Map Platform, featuring interactive maps
 - **360° Image Viewer**: Pannellum integration for immersive viewing
 - **Drag & Drop**: Place ordering and management with @dnd-kit
 - **File Upload**: Drag & drop file uploads with react-dropzone
-- **Real-time Routing**: OpenRouteService integration for real road route calculation
+- **Real-time Routing**: OSRM integration for real road route calculation
 - **Project Management**: Create and manage mapping projects
 - **Responsive Design**: Tailwind CSS for modern, mobile-friendly UI
 
@@ -144,28 +144,23 @@ The application is designed to work on:
 |----------|-------------|----------|---------|
 | `NEXT_PUBLIC_MAP_STYLE` | Map style URL | Yes | MapLibre demo style |
 | `NEXT_PUBLIC_BACKEND_URL` | Backend API URL | Yes | `http://localhost:4000` |
-| `NEXT_PUBLIC_OPENROUTE_API_KEY` | OpenRouteService API key for real road routing | No | - |
+| `NEXT_PUBLIC_OSRM_HOST` | OSRM server URL (e.g. http://localhost:5000) | No | router.project-osrm.org |
 | `NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN` | Mapbox token | No | - |
 
 ## 🛣️ Real Road Routing
 
-The application now supports real car road routing using **OpenRouteService**:
+The application now supports real road routing using the **Open Source Routing Machine (OSRM)** service.
 
 ### Features
 - **Real Road Paths**: Routes follow actual road networks instead of straight lines
-- **Multiple Routing Profiles**: 
-  - `driving-car`: Standard car routing
-  - `driving-eco`: Eco-friendly routes
-  - `driving-fast`: Fastest routes
-- **Waypoint Optimization**: Intelligent intermediate points for realistic routing
-- **Fallback Support**: Graceful fallback to enhanced mock routing when API unavailable
+- **Supported Profiles**: `driving`, `walking`, `cycling`
+- **Fallback Support**: Graceful fallback to enhanced mock routing when the service is unavailable
 
 ### Setup
-1. Get a free API key from [OpenRouteService](https://openrouteservice.org/dev/#/signup)
-2. Add to `.env.local`: `NEXT_PUBLIC_OPENROUTE_API_KEY=your_key_here`
-3. Routes will automatically use real road data
+1. (Optional) Self-host an OSRM server or use the public demo at `https://router.project-osrm.org`
+2. Add to `.env.local` if self-hosting: `NEXT_PUBLIC_OSRM_HOST=http://localhost:5000`
+3. Routes will automatically use the configured OSRM server
 
 ### Route Visualization
 - **Enhanced Styling**: Thicker lines with white outlines for better visibility
 - **Road Network**: Routes curve and follow realistic road paths
-- **Distance-Based**: Longer routes include more waypoints for accuracy

--- a/map-platform-frontend/app/page.tsx
+++ b/map-platform-frontend/app/page.tsx
@@ -8,6 +8,7 @@ import { useDroppable, DndContext, closestCenter, PointerSensor, useSensor, useS
 import { SortableContext, useSortable, arrayMove, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { useDropzone } from 'react-dropzone';
+import { getRoute, formatKm, formatHhMm } from '@/lib/osrm';
 
 // MapLibre needs window -> use dynamic import to avoid SSR issues
 const MapLibreGL = dynamic(() => import('maplibre-gl'), { ssr: false });
@@ -195,113 +196,33 @@ async function computeRoute(projectId, placeId) {
       return res.json(); // {encoded, distance_m, duration_s, pretty}
     }
     
-    // Fallback to OpenRouteService for real road routing
-    console.log('Backend not available, using OpenRouteService for real road routing');
-    
+    // Fallback to OSRM for real road routing
+    console.log('Backend not available, using OSRM for real road routing');
+
     const project = useStudio.getState().project;
     const secondaryPlace = project.secondaries.find(p => p._id === placeId || p.name.includes('Place'));
-    
+
     if (!secondaryPlace) {
       throw new Error('Secondary place not found');
     }
-    
-    // Use OpenRouteService for real road routing
-    const openRouteApiKey = process.env.NEXT_PUBLIC_OPENROUTE_API_KEY;
-    if (!openRouteApiKey) {
-      console.warn('No OpenRouteService API key found, using S-curve routing for realistic paths');
-      return generateSCurveRoute(project.principal, secondaryPlace);
-    }
-    
-    // OpenRouteService API endpoint - use driving-car for realistic car routes
-    const apiUrl = 'https://api.openrouteservice.org/v2/directions/driving-car';
-    
-    // Create route from principal to secondary place with simple coordinates
-    // OpenRouteService expects [longitude, latitude] format
-    const coordinates = [
+
+    const coords = [
       [project.principal.longitude, project.principal.latitude],
       [secondaryPlace.longitude, secondaryPlace.latitude]
     ];
-    
-    // Validate coordinates
-    const isValidCoordinate = (coord) => {
-      return Array.isArray(coord) && 
-             coord.length === 2 && 
-             typeof coord[0] === 'number' && 
-             typeof coord[1] === 'number' &&
-             !isNaN(coord[0]) && 
-             !isNaN(coord[1]) &&
-             coord[0] >= -180 && coord[0] <= 180 && // longitude range
-             coord[1] >= -90 && coord[1] <= 90;     // latitude range
-    };
-    
-    if (!coordinates.every(isValidCoordinate)) {
-      console.warn('Invalid coordinates detected, using S-curve routing');
-      return generateSCurveRoute(project.principal, secondaryPlace);
-    }
-    
-    // Debug the coordinates being sent
-    console.log('OpenRouteService coordinates:', coordinates);
-    console.log('Principal location:', { lng: project.principal.longitude, lat: project.principal.latitude });
-    console.log('Secondary location:', { lng: secondaryPlace.longitude, lat: secondaryPlace.latitude });
-    
-    const requestBody = {
-      coordinates: coordinates,
-      format: 'geojson',
-      preference: 'fastest',
-      units: 'm', // OpenRouteService expects 'm' not 'meters'
-      instructions: false,
-      geometry: true // OpenRouteService expects boolean true, not 'full'
-    };
-    
-    console.log('OpenRouteService request body:', requestBody);
-    
-    const response = await fetch(apiUrl, {
-      method: 'POST',
-      headers: {
-        'Authorization': openRouteApiKey,
-        'Content-Type': 'application/json',
-        'Accept': 'application/json'
-      },
-      body: JSON.stringify(requestBody)
-    });
-    
-    if (!response.ok) {
-      const errorText = await response.text();
-      console.error('OpenRouteService error response:', errorText);
-      console.error('Response status:', response.status);
-      console.error('Response headers:', Object.fromEntries(response.headers.entries()));
-      throw new Error(`OpenRouteService API error: ${response.status} - ${errorText}`);
-    }
-    
-    const routeData = await response.json();
-    console.log('OpenRouteService API response:', routeData);
-    
-    if (!routeData.routes || routeData.routes.length === 0) {
-      console.warn('OpenRouteService returned no routes:', routeData);
-      throw new Error('No route found');
-    }
-    
-    const route = routeData.routes[0];
-    const properties = route;
-    
-    // Extract route information
-    const distance = route.distance || 0;
-    const duration = route.duration || 0;
-    
-    // Convert coordinates to polyline format for MapLibre
-    const coordinates_array = route.geometry.coordinates;
-    const polyline = encodePolyline(coordinates_array);
-    
+
+    const { geometry, distanceMeters, durationSeconds } = await getRoute({ coords, profile: 'driving' });
+    const polyline = encodePolyline(geometry.coordinates);
+
     return {
       encoded: polyline,
-      distance_m: Math.round(distance),
-      duration_s: Math.round(duration),
+      distance_m: Math.round(distanceMeters),
+      duration_s: Math.round(durationSeconds),
       pretty: {
-        distance: `${(distance / 1000).toFixed(1)} km`,
-        time: `${Math.round(duration / 60)} min`
+        distance: formatKm(distanceMeters),
+        time: formatHhMm(durationSeconds)
       },
-      // Add GeoJSON for direct rendering
-      geojson: route
+      geojson: { type: 'Feature', properties: {}, geometry }
     };
     
   } catch (error) {
@@ -923,7 +844,7 @@ function MapCanvas() {
         let feature;
         let routeId = `route-${idx}`;
         
-        // Check if we have GeoJSON data (from OpenRouteService)
+        // Check if we have GeoJSON data (from routing API)
         if (s.routeGeoJSON) {
           // Use the actual GeoJSON route data
           feature = s.routeGeoJSON;

--- a/map-platform-frontend/env-config.txt
+++ b/map-platform-frontend/env-config.txt
@@ -6,9 +6,9 @@ NEXT_PUBLIC_MAP_STYLE=https://demotiles.maplibre.org/style.json
 # Backend API
 NEXT_PUBEND_URL=http://localhost:4000
 
-# OpenRouteService API Key for Real Road Routing
-# Get your free API key at: https://openrouteservice.org/dev/#/signup
-NEXT_PUBLIC_OPENROUTE_API_KEY=your_openroute_api_key_here
+# OSRM routing server
+# Defaults to public demo if not set
+NEXT_PUBLIC_OSRM_HOST=http://localhost:5000
 
 # Optional: Mapbox (if you want to use Mapbox instead of MapLibre)
 # NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN=your_mapbox_token_here 

--- a/map-platform-frontend/lib/osrm.ts
+++ b/map-platform-frontend/lib/osrm.ts
@@ -1,0 +1,126 @@
+/**
+ * OSRM routing utilities.
+ *
+ * Provides a `getRoute` function that fetches routes from an OSRM server and
+ * helpers for formatting distance and duration.
+ *
+ * The default host falls back to the public demo server if no environment
+ * variable is supplied.
+ *
+ * @module osrm
+ */
+
+const DEFAULT_HOST = process.env.NEXT_PUBLIC_OSRM_HOST || 'https://router.project-osrm.org';
+
+/** Mapping from generic profile names to OSRM profiles. */
+const PROFILE_MAP: Record<string, string> = {
+  driving: 'driving',
+  walking: 'foot',
+  cycling: 'bike'
+};
+
+/**
+ * Format metres to kilometres with one decimal.
+ *
+ * @param {number} meters
+ * @returns {string} e.g. `"12.3 km"`
+ * @example
+ * formatKm(1234); // '1.2 km'
+ */
+export function formatKm(meters: number): string {
+  return `${(meters / 1000).toFixed(1)} km`;
+}
+
+/**
+ * Format seconds to `hh:mm` (rounded to minutes).
+ *
+ * @param {number} seconds
+ * @returns {string} e.g. `"01:05"`
+ * @example
+ * formatHhMm(3750); // '01:02'
+ */
+export function formatHhMm(seconds: number): string {
+  const minutes = Math.round(seconds / 60);
+  const hh = String(Math.floor(minutes / 60)).padStart(2, '0');
+  const mm = String(minutes % 60).padStart(2, '0');
+  return `${hh}:${mm}`;
+}
+
+export interface RouteParams {
+  coords: [number, number][];
+  profile: 'driving' | 'walking' | 'cycling';
+  host?: string;
+}
+
+export interface RouteResult {
+  geometry: GeoJSON.LineString;
+  distanceMeters: number;
+  durationSeconds: number;
+}
+
+/**
+ * Fetch a route from OSRM.
+ *
+ * @param {RouteParams} params
+ * @returns {Promise<RouteResult>}
+ * @throws {Error} on validation failure or missing route
+ *
+ * @example
+ * const route = await getRoute({
+ *   coords: [[-122.42, 37.78], [-122.45, 37.91]],
+ *   profile: 'driving'
+ * });
+ * map.getSource('route-source').setData({
+ *   type: 'Feature',
+ *   geometry: route.geometry,
+ *   properties: {}
+ * });
+ * map.addLayer({ id: 'route-line', type: 'line', source: 'route-source' });
+ * const summary = `${formatKm(route.distanceMeters)} • ${formatHhMm(route.durationSeconds)}`;
+ */
+export async function getRoute({ coords, profile, host = DEFAULT_HOST }: RouteParams): Promise<RouteResult> {
+  if (!Array.isArray(coords) || coords.length < 2) {
+    throw new Error('coords must contain at least two [lng,lat] pairs');
+  }
+  if (!['driving', 'walking', 'cycling'].includes(profile)) {
+    throw new Error(`Unsupported profile: ${profile}`);
+  }
+  const osrmProfile = PROFILE_MAP[profile];
+  const coordStr = coords.map(c => {
+    if (!Array.isArray(c) || c.length !== 2 || c.some(v => typeof v !== 'number' || Number.isNaN(v))) {
+      throw new Error('Invalid coordinate in coords');
+    }
+    return `${c[0]},${c[1]}`;
+  }).join(';');
+
+  const url = `${host.replace(/\/$/, '')}/route/v1/${osrmProfile}/${coordStr}?overview=full&geometries=geojson&steps=true&alternatives=false`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`OSRM request failed: ${res.status}`);
+  }
+  const data = await res.json();
+  if (!data.routes || !data.routes[0]) {
+    throw new Error('No route found');
+  }
+  const route = data.routes[0];
+  return {
+    geometry: route.geometry,
+    distanceMeters: route.distance,
+    durationSeconds: route.duration
+  };
+}
+
+// Minimal inline tests for format helpers
+// Run with vitest: `vitest run lib/osrm.test.ts`
+// These tests execute only when using Vitest's import.meta.vitest
+if (import.meta.vitest) {
+  const { it, expect } = import.meta.vitest;
+  it('formatKm', () => {
+    expect(formatKm(1234)).toBe('1.2 km');
+  });
+  it('formatHhMm', () => {
+    expect(formatHhMm(3660)).toBe('01:01');
+  });
+}
+
+export default getRoute;


### PR DESCRIPTION
## Summary
- add OSRM-based routing logic to backend controllers
- simplify place routing mount and document OSRM host configuration
- remove legacy Mapbox/GraphHopper env settings

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68a8cabb3da08324ba4e582aa64db216