### PR TITLE
Add interactive place menu and route export support

### DIFF
--- a/map-platform-backend/src/services/export.service.js
+++ b/map-platform-backend/src/services/export.service.js
@@ -32,12 +32,14 @@ export function buildExportData(doc, { styleURL, profiles = ['driving'] } = {}) 
   const secondaries = (doc.secondaries || []).map((s) => {
     const routes = [];
     if (s.routesFromBase && s.routesFromBase.length) {
-      const coords = decodePolyline(s.routesFromBase[0]);
-      routes.push({
-        profile: profiles[0] || 'driving',
-        distance_m: null,
-        duration_s: null,
-        geometry: { type: 'LineString', coordinates: coords }
+      s.routesFromBase.forEach((poly, idx) => {
+        const coords = decodePolyline(poly);
+        routes.push({
+          profile: profiles[idx] || profiles[0] || 'driving',
+          distance_m: null,
+          duration_s: null,
+          geometry: { type: 'LineString', coordinates: coords }
+        });
       });
     }
     return {

--- a/map-platform-backend/src/services/export.service.test.js
+++ b/map-platform-backend/src/services/export.service.test.js
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert';
 import { buildExportData } from './export.service.js';
+import polyline from 'polyline';
 
 test('buildExportData throws when missing principal', () => {
   assert.throws(() => buildExportData({}), /NoPrincipal/);
@@ -23,4 +24,39 @@ test('buildExportData returns structured data', () => {
   const data = buildExportData(doc);
   assert.equal(data.project.title, 'Demo');
   assert.equal(data.principal.name, 'Home');
+});
+
+test('buildExportData includes routes', () => {
+  const encoded = polyline.encode([
+    [0, 0],
+    [0, 1]
+  ]);
+  const doc = {
+    _id: '1',
+    title: 'Demo',
+    principal: {
+      _id: 'p',
+      name: 'Home',
+      latitude: 0,
+      longitude: 0,
+      category: 'Principal',
+      footerInfo: {}
+    },
+    secondaries: [
+      {
+        _id: 's',
+        name: 'Sec',
+        latitude: 0,
+        longitude: 1,
+        routesFromBase: [encoded],
+        footerInfo: {}
+      }
+    ]
+  };
+  const data = buildExportData(doc);
+  assert.equal(data.secondaries[0].routes.length, 1);
+  assert.equal(
+    data.secondaries[0].routes[0].geometry.type,
+    'LineString'
+  );
 });

--- a/map-platform-backend/src/templates/app.js
+++ b/map-platform-backend/src/templates/app.js
@@ -6,17 +6,65 @@
     center: [data.principal.lon, data.principal.lat],
     zoom: data.principal.zoom || 13
   });
-  // markers
+
   new maplibregl.Marker({ color: 'red' })
     .setLngLat([data.principal.lon, data.principal.lat])
     .addTo(map);
+
+  const routeLayers = {};
+
   data.secondaries.forEach(s => {
     new maplibregl.Marker()
       .setLngLat([s.lon, s.lat])
       .addTo(map);
-    (s.routes||[]).forEach((r,i)=>{
-      map.addSource(`${s.id}-${i}`, { type:'geojson', data:{ type:'Feature', geometry:r.geometry }});
-      map.addLayer({ id:`${s.id}-${i}`, type:'line', source:`${s.id}-${i}`, paint:{'line-color':'#3887be','line-width':3}});
+
+    if (s.routes && s.routes.length) {
+      routeLayers[s.id] = [];
+      s.routes.forEach((r,i)=>{
+        const sourceId = `${s.id}-${i}`;
+        const layerId = `${s.id}-${i}`;
+        map.addSource(sourceId, { type:'geojson', data:{ type:'Feature', geometry:r.geometry }});
+        map.addLayer({ id:layerId, type:'line', source:sourceId, layout:{visibility:'none'}, paint:{'line-color':'#3887be','line-width':3}});
+        routeLayers[s.id].push(layerId);
+      });
+    }
+  });
+
+  const menu = document.getElementById('menu');
+  const pano = document.getElementById('pano');
+  const routeBtn = document.getElementById('routeBtn');
+  let viewer;
+
+  data.secondaries.forEach(s => {
+    const btn = document.createElement('button');
+    btn.textContent = s.name;
+    btn.addEventListener('click', () => {
+      map.flyTo({ center:[s.lon, s.lat], zoom:14 });
+
+      Object.values(routeLayers).flat().forEach(id => {
+        map.setLayoutProperty(id, 'visibility', 'none');
+      });
+
+      if (s.virtualtour) {
+        pano.style.display = 'block';
+        if (viewer && viewer.destroy) viewer.destroy();
+        viewer = pannellum.viewer('pano', { type:'equirectangular', panorama:s.virtualtour });
+      } else {
+        pano.style.display = 'none';
+      }
+
+      if (routeLayers[s.id] && routeLayers[s.id].length) {
+        routeBtn.style.display = 'block';
+        routeBtn.onclick = () => {
+          routeLayers[s.id].forEach(id => {
+            map.setLayoutProperty(id, 'visibility', 'visible');
+          });
+        };
+      } else {
+        routeBtn.style.display = 'none';
+        routeBtn.onclick = null;
+      }
     });
+    menu.appendChild(btn);
   });
 })();

--- a/map-platform-backend/src/templates/map.html
+++ b/map-platform-backend/src/templates/map.html
@@ -7,7 +7,9 @@
   {{LIB_STYLES}}
 </head>
 <body>
+  <header id="header"><nav id="menu"></nav><button id="routeBtn" style="display:none">Show Route</button></header>
   <div id="map" class="map"></div>
+  <div id="pano" class="pano"></div>
   {{INLINE_DATA}}
   {{LIB_SCRIPTS}}
   <script src="./assets/js/app.js"></script>

--- a/map-platform-backend/src/templates/styles.css
+++ b/map-platform-backend/src/templates/styles.css
@@ -1,2 +1,5 @@
-html,body,#map{margin:0;padding:0;height:100%;width:100%;}
-#map{position:absolute;top:0;bottom:0;}
+html,body{margin:0;padding:0;height:100%;width:100%;}
+#map{position:absolute;top:50px;bottom:0;width:100%;}
+#header{position:absolute;top:0;left:0;right:0;height:50px;background:#fff;z-index:1;display:flex;align-items:center;gap:8px;padding:4px;}
+#menu button{margin-right:8px;}
+#pano{position:absolute;bottom:10px;right:10px;width:300px;height:200px;display:none;z-index:1;}


### PR DESCRIPTION
## Summary
- include all stored routes when exporting project data
- add header menu in exported map to navigate to secondary places
- show 360° image and reveal route on demand

## Testing
- `npm test` *(fails: Cannot find package 'polyline')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/archiver)*

------
https://chatgpt.com/codex/tasks/task_e_68ab56e83d54832491bd6b787fb587d3