### PR TITLE
feat(export): use real project logo

### DIFF
--- a/map-platform-backend/src/services/export.service.js
+++ b/map-platform-backend/src/services/export.service.js
@@ -7,6 +7,7 @@ import archiver from 'archiver';
 import { Project } from '../models/Project.js';
 import { decodePolyline } from '../utils/polyline.js';
 import { slugify } from '../utils/slug.js';
+import { download } from '../utils/download.js';
 
 /**
  * Normalize the DB doc into the export JSON consumed by the static bundle.
@@ -78,11 +79,11 @@ export function buildExportData(doc, { styleURL, profiles = ['driving'] } = {}) 
 /**
  * Export a project as a static bundle and stream it as a ZIP file.
  * @param {string} projectId
- * @param {{ inlineData?: boolean, includeLocalLibs?: boolean, styleURL?: string, profiles?: string[] }} options
+ * @param {{ inlineData?: boolean, includeLocalLibs?: boolean, mirrorImagesLocally?: boolean, styleURL?: string, profiles?: string[] }} options
  * @param {import('express').Response} res
  */
 export async function exportProject(projectId, options, res) {
-  const { inlineData = false, includeLocalLibs = true } = options || {};
+  const { inlineData = false, includeLocalLibs = true, mirrorImagesLocally = true } = options || {};
 
   const doc = await Project.findById(projectId).lean();
   const data = buildExportData(doc, options);
@@ -92,6 +93,22 @@ export async function exportProject(projectId, options, res) {
   const assetsDir = path.join(tmpDir, 'assets');
   await fs.promises.mkdir(path.join(assetsDir, 'js'), { recursive: true });
   await fs.promises.mkdir(path.join(assetsDir, 'css'), { recursive: true });
+  await fs.promises.mkdir(path.join(assetsDir, 'img'), { recursive: true });
+
+  // logo asset handling
+  if (data.project.logo?.src) {
+    if (mirrorImagesLocally) {
+      try {
+        const url = data.project.logo.src;
+        const ext = path.extname(new URL(url).pathname) || '.png';
+        const dest = path.join(assetsDir, 'img', `logo${ext}`);
+        await download(url, dest);
+        data.project.logo.src = `./assets/img/logo${ext}`;
+      } catch {
+        // keep remote URL on failure
+      }
+    }
+  }
 
   // data/project.json unless we inline
   if (!inlineData) {
@@ -146,11 +163,16 @@ export async function exportProject(projectId, options, res) {
     ? `<script>window.__PROJECT__ = ${JSON.stringify(data)};</script>`
     : '';
 
+  const logoHtml = data.project.logo?.src
+    ? `<img src="${data.project.logo.src}" alt="${data.project.title}" class="logo-img" /> <span class="logo-text">${data.project.title}</span>`
+    : `<span class="logo-text">${data.project.title}</span>`;
+
   const html = mapTpl
     .replace('{{TITLE}}', data.project.title)
     .replace('{{LIB_STYLES}}', libStyles)
     .replace('{{LIB_SCRIPTS}}', libScripts)
-    .replace('{{INLINE_DATA}}', inlineDataStr);
+    .replace('{{INLINE_DATA}}', inlineDataStr)
+    .replace('{{HEADER_LOGO}}', logoHtml);
 
   await fs.promises.writeFile(path.join(tmpDir, 'map.html'), html, 'utf8');
   await fs.promises.writeFile(path.join(assetsDir, 'js', 'app.js'), appJs, 'utf8');

--- a/map-platform-backend/src/templates/map.html
+++ b/map-platform-backend/src/templates/map.html
@@ -10,7 +10,7 @@
 <body>
   <!-- Header -->
   <header id="header" class="header">
-    <div class="logo">◆ROF PRAMASA</div>
+    <div id="logo" class="logo">{{HEADER_LOGO}}</div>
     <nav>
       <ul id="mainMenu" class="nav-menu">
         <li><a href="#" class="active" onclick="showHome()">Home</a></li>

--- a/map-platform-backend/src/templates/styles.css
+++ b/map-platform-backend/src/templates/styles.css
@@ -28,10 +28,20 @@ body {
 }
 
 .logo {
+  display: flex;
+  align-items: center;
+  margin-right: 50px;
+}
+
+.logo-img {
+  height: 40px;
+  margin-right: 10px;
+}
+
+.logo-text {
   color: white;
   font-size: 24px;
   font-weight: bold;
-  margin-right: 50px;
 }
 
 .nav-menu {


### PR DESCRIPTION
## Summary
- replace placeholder logo with project's actual logo in exported map
- mirror logo asset locally when requested and update header markup/styles

## Testing
- `npm test` (backend) *(fails: Cannot find package 'polyline' and npm install forbidden)*
- `npm test` (frontend) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ada7c9aef88324b90710cf281b5ebd