### PR TITLE
Mirror panoramas and show distance/time in exports

### DIFF
--- a/map-platform-backend/src/services/export.service.js
+++ b/map-platform-backend/src/services/export.service.js
@@ -7,6 +7,7 @@ import archiver from 'archiver';
 import { Project } from '../models/Project.js';
 import { decodePolyline } from '../utils/polyline.js';
 import { slugify } from '../utils/slug.js';
+import { download } from '../utils/download.js';
 
 /**
  * Normalize the DB doc into the export JSON consumed by the static bundle.
@@ -78,11 +79,11 @@ export function buildExportData(doc, { styleURL, profiles = ['driving'] } = {}) 
 /**
  * Export a project as a static bundle and stream it as a ZIP file.
  * @param {string} projectId
- * @param {{ inlineData?: boolean, includeLocalLibs?: boolean, styleURL?: string, profiles?: string[] }} options
+ * @param {{ inlineData?: boolean, includeLocalLibs?: boolean, mirrorImagesLocally?: boolean, styleURL?: string, profiles?: string[] }} options
  * @param {import('express').Response} res
  */
 export async function exportProject(projectId, options, res) {
-  const { inlineData = false, includeLocalLibs = true } = options || {};
+  const { inlineData = false, includeLocalLibs = true, mirrorImagesLocally = true } = options || {};
 
   const doc = await Project.findById(projectId).lean();
   const data = buildExportData(doc, options);
@@ -90,8 +91,58 @@ export async function exportProject(projectId, options, res) {
   // temp dir
   const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'export-'));
   const assetsDir = path.join(tmpDir, 'assets');
+  const imagesDir = path.join(tmpDir, 'images');
   await fs.promises.mkdir(path.join(assetsDir, 'js'), { recursive: true });
   await fs.promises.mkdir(path.join(assetsDir, 'css'), { recursive: true });
+  await fs.promises.mkdir(imagesDir, { recursive: true });
+
+  // logo asset handling
+  if (data.project.logo?.src) {
+    if (mirrorImagesLocally) {
+      try {
+        const url = data.project.logo.src;
+        const ext = path.extname(new URL(url).pathname) || '.png';
+        const dest = path.join(imagesDir, `logo${ext}`);
+        await download(url, dest);
+        data.project.logo.src = `./images/logo${ext}`;
+      } catch {
+        // keep remote URL on failure
+      }
+    }
+  }
+
+  // panorama asset handling
+  if (mirrorImagesLocally) {
+    const panoTasks = [];
+
+    if (data.principal.virtualtour) {
+      panoTasks.push(async () => {
+        try {
+          const url = data.principal.virtualtour;
+          const ext = path.extname(new URL(url).pathname) || '.jpg';
+          const dest = path.join(imagesDir, `pano-principal${ext}`);
+          await download(url, dest);
+          data.principal.virtualtour = `./images/pano-principal${ext}`;
+        } catch {}
+      });
+    }
+
+    data.secondaries.forEach((s) => {
+      if (s.virtualtour) {
+        panoTasks.push(async () => {
+          try {
+            const url = s.virtualtour;
+            const ext = path.extname(new URL(url).pathname) || '.jpg';
+            const dest = path.join(imagesDir, `pano-${s.id}${ext}`);
+            await download(url, dest);
+            s.virtualtour = `./images/pano-${s.id}${ext}`;
+          } catch {}
+        });
+      }
+    });
+
+    await Promise.all(panoTasks.map((fn) => fn()));
+  }
 
   // data/project.json unless we inline
   if (!inlineData) {
@@ -146,11 +197,16 @@ export async function exportProject(projectId, options, res) {
     ? `<script>window.__PROJECT__ = ${JSON.stringify(data)};</script>`
     : '';
 
+  const logoHtml = data.project.logo?.src
+    ? `<img src="${data.project.logo.src}" alt="${data.project.title}" class="logo-img" /> <span class="logo-text">${data.project.title}</span>`
+    : `<span class="logo-text">${data.project.title}</span>`;
+
   const html = mapTpl
     .replace('{{TITLE}}', data.project.title)
     .replace('{{LIB_STYLES}}', libStyles)
     .replace('{{LIB_SCRIPTS}}', libScripts)
-    .replace('{{INLINE_DATA}}', inlineDataStr);
+    .replace('{{INLINE_DATA}}', inlineDataStr)
+    .replace('{{HEADER_LOGO}}', logoHtml);
 
   await fs.promises.writeFile(path.join(tmpDir, 'map.html'), html, 'utf8');
   await fs.promises.writeFile(path.join(assetsDir, 'js', 'app.js'), appJs, 'utf8');

--- a/map-platform-backend/src/templates/app.js
+++ b/map-platform-backend/src/templates/app.js
@@ -68,6 +68,9 @@
     const panel = document.getElementById('infoPanel');
     const title = document.getElementById('infoTitle');
     const container = document.getElementById('panoSmall');
+    const distanceEl = document.getElementById('infoDistance');
+    const timeEl = document.getElementById('infoTime');
+    const meta = document.getElementById('infoMeta');
 
     title.textContent = project.name;
     panel.classList.remove('hidden');
@@ -78,14 +81,24 @@
     }
     container.innerHTML = '';
 
+    distanceEl.textContent = project.footerInfo?.distanceText || '';
+    timeEl.textContent = project.footerInfo?.timeText || '';
+    if (distanceEl.textContent || timeEl.textContent) {
+      meta.style.display = 'flex';
+    } else {
+      meta.style.display = 'none';
+    }
+
     if (project.virtualtour) {
       viewer = pannellum.viewer('panoSmall', {
         type: 'equirectangular',
         panorama: project.virtualtour,
+        crossOrigin: 'anonymous',
         autoLoad: true,
         showControls: true,
         hfov: 100
       });
+      viewer.on('load', () => viewer.resize());
     }
   }
 

--- a/map-platform-backend/src/templates/map.html
+++ b/map-platform-backend/src/templates/map.html
@@ -10,7 +10,7 @@
 <body>
   <!-- Header -->
   <header id="header" class="header">
-    <div class="logo">◆ROF PRAMASA</div>
+    <div id="logo" class="logo">{{HEADER_LOGO}}</div>
     <nav>
       <ul id="mainMenu" class="nav-menu">
         <li><a href="#" class="active" onclick="showHome()">Home</a></li>
@@ -38,6 +38,10 @@
       </div>
       <div class="info-body">
         <div id="panoSmall" class="pano-small"></div>
+        <div id="infoMeta" class="info-meta">
+          <span id="infoDistance"></span>
+          <span id="infoTime"></span>
+        </div>
         <div class="info-actions">
           <button id="showRouteBtn" class="route-button" onclick="showRoute()">Show Route</button>
         </div>

--- a/map-platform-backend/src/templates/styles.css
+++ b/map-platform-backend/src/templates/styles.css
@@ -28,10 +28,20 @@ body {
 }
 
 .logo {
+  display: flex;
+  align-items: center;
+  margin-right: 50px;
+}
+
+.logo-img {
+  height: 40px;
+  margin-right: 10px;
+}
+
+.logo-text {
   color: white;
   font-size: 24px;
   font-weight: bold;
-  margin-right: 50px;
 }
 
 .nav-menu {
@@ -290,6 +300,7 @@ body {
 
 .info-body { padding: 12px; }
 .pano-small { width: 100%; height: 220px; background: #f3f4f6; border-radius: 10px; overflow: hidden; }
+.info-meta { margin-top: 8px; font-size: 14px; color: #4b5563; display: flex; gap: 8px; }
 .info-actions { display:flex; justify-content:flex-end; margin-top: 10px; }
 
 /* Hide legacy elements if any remain */


### PR DESCRIPTION
## Summary
- Mirror principal and secondary panorama images into export bundle and rewrite references for offline viewing
- Show secondary place distance and time in info panel with new markup and styling

## Testing
- `npm test` (backend) *(fails: Cannot find package 'polyline' imported in tests)*
- `npm test` (frontend) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ada7c9aef88324b90710cf281b5ebd