### PR TITLE
Default inline project data and add loading state

### DIFF
--- a/map-platform-backend/Exports/Project/assets/css/styles.css
+++ b/map-platform-backend/Exports/Project/assets/css/styles.css
@@ -11,6 +11,19 @@ body {
   overflow: hidden;
 }
 
+#loading {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #ffffff;
+  z-index: 2000;
+}
+
 /* Header Styles */
 .header {
   position: fixed;

--- a/map-platform-backend/Exports/Project/assets/js/app.js
+++ b/map-platform-backend/Exports/Project/assets/js/app.js
@@ -1,4 +1,5 @@
 (async function(){
+  const loadingEl = document.getElementById('loading');
   const data = window.__PROJECT__ || await fetch('./data/project.json').then(r=>r.json());
   
   let map;
@@ -30,6 +31,10 @@
     });
 
     map.addControl(new maplibregl.NavigationControl({ visualizePitch: true }));
+
+    map.on('load', () => {
+      if (loadingEl) loadingEl.style.display = 'none';
+    });
 
     map.on('error', (error) => {
       if (error?.error?.message?.includes('tile')) {

--- a/map-platform-backend/Exports/Project/map.html
+++ b/map-platform-backend/Exports/Project/map.html
@@ -9,6 +9,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/pannellum@2.5.6/build/pannellum.css" />
 </head>
 <body>
+  <div id="loading" class="loading">Loading...</div>
   <!-- Header -->
   <header id="header" class="header">
     <div id="logo" class="logo"><img src="./images/logo.jpg" alt="Untitled Project" class="logo-img" /> <span class="logo-text">Untitled Project</span></div>

--- a/map-platform-backend/src/services/export.service.js
+++ b/map-platform-backend/src/services/export.service.js
@@ -79,10 +79,11 @@ export function buildExportData(doc, { styleURL, profiles = ['driving'] } = {}) 
  * Export a project as a static bundle and stream it as a ZIP file.
  * @param {string} projectId
  * @param {{ inlineData?: boolean, includeLocalLibs?: boolean, mirrorImagesLocally?: boolean, styleURL?: string, profiles?: string[] }} options
+ *  inlineData defaults to true to embed project data and avoid file:// CORS issues.
  * @param {import('express').Response} res
  */
 export async function exportProject(projectId, options, res) {
-  const { inlineData = false, includeLocalLibs = true, mirrorImagesLocally = true } = options || {};
+  const { inlineData = true, includeLocalLibs = true, mirrorImagesLocally = true } = options || {};
 
   const doc = await Project.findById(projectId).lean();
   const data = buildExportData(doc, options);

--- a/map-platform-backend/src/templates/app.js
+++ b/map-platform-backend/src/templates/app.js
@@ -1,4 +1,5 @@
 (async function(){
+  const loadingEl = document.getElementById('loading');
   const data = window.__PROJECT__ || await fetch('./data/project.json').then(r=>r.json());
   
   let map;
@@ -30,6 +31,10 @@
     });
 
     map.addControl(new maplibregl.NavigationControl({ visualizePitch: true }));
+
+    map.on('load', () => {
+      if (loadingEl) loadingEl.style.display = 'none';
+    });
 
     map.on('error', (error) => {
       if (error?.error?.message?.includes('tile')) {

--- a/map-platform-backend/src/templates/map.html
+++ b/map-platform-backend/src/templates/map.html
@@ -8,6 +8,7 @@
   {{LIB_STYLES}}
 </head>
 <body>
+  <div id="loading" class="loading">Loading...</div>
   <!-- Header -->
   <header id="header" class="header">
     <div id="logo" class="logo">{{HEADER_LOGO}}</div>

--- a/map-platform-backend/src/templates/styles.css
+++ b/map-platform-backend/src/templates/styles.css
@@ -11,6 +11,19 @@ body {
   overflow: hidden;
 }
 
+#loading {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #ffffff;
+  z-index: 2000;
+}
+
 /* Header Styles */
 .header {
   position: fixed;

--- a/map-platform-frontend/app/page.tsx
+++ b/map-platform-frontend/app/page.tsx
@@ -1141,7 +1141,7 @@ export default function MappingStudio() {
   const [exporting, setExporting] = useState(false);
   const [expOpts, setExpOpts] = useState({
     mirrorImagesLocally: true,
-    inlineData: false,
+    inlineData: true,
     includeLocalLibs: true,
     styleURL: 'satellite',
     profiles: ['driving'],


### PR DESCRIPTION
## Summary
- Embed project JSON by default to sidestep file:// CORS, with optional external project.json
- Add simple loading overlay and delay map init until data loaded
- Default frontend export option to inline project data

## Testing
- `npm test` (fails: Cannot find package 'polyline' / 'archiver')
- `npm run lint` (fails: next: not found)


------
https://chatgpt.com/codex/tasks/task_e_68b22dc448448324b38f9e6ad5f4e84b