### PR TITLE
Default inline project data, add loading state, and fix route coordinates

### DIFF
--- a/map-platform-backend/Exports/Project/assets/css/styles.css
+++ b/map-platform-backend/Exports/Project/assets/css/styles.css
@@ -11,6 +11,19 @@ body {
   overflow: hidden;
 }
 
+#loading {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #ffffff;
+  z-index: 2000;
+}
+
 /* Header Styles */
 .header {
   position: fixed;
@@ -270,38 +283,88 @@ body {
   }
 }
 
-/* Info Panel (right side) */
-.info-panel {
-  position: fixed;
-  top: 80px;
-  right: 16px;
-  width: 360px;
-  max-height: calc(100vh - 100px);
-  background: rgba(255,255,255,0.98);
-  box-shadow: 0 10px 30px rgba(0,0,0,0.2);
-  border-radius: 16px;
-  overflow: hidden;
-  z-index: 1200;
+/* Secondary places sidebar */
+.secondary-sidebar {
+  width: 320px;
+  background: rgba(255,255,255,0.95);
+  backdrop-filter: blur(10px);
+  border-left: 1px solid rgba(0,0,0,0.1);
+  overflow-y: auto;
+  z-index: 100;
   display: flex;
   flex-direction: column;
 }
-.hidden { display: none; }
 
-.info-header {
+.secondary-list {
+  list-style: none;
+  padding: 10px;
+}
+
+.secondary-item {
+  padding: 8px;
+  border-bottom: 1px solid #e5e7eb;
+  cursor: pointer;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+
+.secondary-item:hover,
+.secondary-item:focus {
+  background: #f3f4f6;
+  outline: none;
+}
+
+.badge {
+  background: #e5e7eb;
+  border-radius: 4px;
+  padding: 2px 4px;
+  font-size: 12px;
+  line-height: 1;
+}
+
+.details-view {
+  padding: 12px;
+}
+
+.details-back {
+  margin-bottom: 8px;
+}
+
+.coords {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  padding: 12px 14px;
-  background: #111827;
-  color: #fff;
+  gap: 6px;
+  font-size: 14px;
+  margin-bottom: 10px;
 }
-.info-title { font-size: 16px; font-weight: 600; }
-.info-close { background:none; border:none; color:#fff; font-size:22px; cursor:pointer; }
 
-.info-body { padding: 12px; }
+.marker-highlight {
+  transform: scale(1.4);
+}
+
 .pano-small { width: 100%; height: 220px; background: #f3f4f6; border-radius: 10px; overflow: hidden; }
 .info-meta { margin-top: 8px; font-size: 14px; color: #4b5563; display: flex; gap: 8px; }
-.info-actions { display:flex; justify-content:flex-end; margin-top: 10px; }
+
+@media (max-width: 768px) {
+  .secondary-sidebar {
+    width: 100%;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 40%;
+    border-left: none;
+    border-top: 1px solid rgba(0,0,0,0.1);
+  }
+
+  .main-container {
+    padding-bottom: 40%;
+  }
+}
+
+.hidden { display: none; }
 
 /* Hide legacy elements if any remain */
-.sidebar, .modal-overlay { display: none !important; }
+.modal-overlay { display: none !important; }

--- a/map-platform-backend/Exports/Project/assets/js/app.js
+++ b/map-platform-backend/Exports/Project/assets/js/app.js
@@ -1,10 +1,38 @@
 (async function(){
+  const loadingEl = document.getElementById('loading');
   const data = window.__PROJECT__ || await fetch('./data/project.json').then(r=>r.json());
-  
+
   let map;
   let currentProject = null;
   let routeLayerId = null;
   let viewer = null;
+
+  const listView = document.getElementById('listView');
+  const detailsView = document.getElementById('detailsView');
+  const listEl = document.getElementById('secondaryList');
+  const detailTitle = document.getElementById('detailTitle');
+  const detailCoords = document.getElementById('detailCoords');
+  const copyBtn = document.getElementById('copyCoordsBtn');
+  const detailMedia = document.getElementById('detailMedia');
+  const detailDistance = document.getElementById('detailDistance');
+  const detailTime = document.getElementById('detailTime');
+  const routeToggle = document.getElementById('routeToggle');
+  const backBtn = document.getElementById('backBtn');
+
+  function sanitizeLine(coords) {
+    const out = [];
+    coords.forEach((pt) => {
+      if (!Array.isArray(pt) || pt.length < 2) return;
+      let [lon, lat] = pt;
+      if (!isFinite(lon) || !isFinite(lat)) return;
+      if (Math.abs(lon) <= 90 && Math.abs(lat) > 90) {
+        [lon, lat] = [lat, lon];
+      }
+      if (Math.abs(lat) > 90 || Math.abs(lon) > 180) return;
+      out.push([lon, lat]);
+    });
+    return out;
+  }
 
   function initMap() {
     map = new maplibregl.Map({
@@ -31,6 +59,19 @@
 
     map.addControl(new maplibregl.NavigationControl({ visualizePitch: true }));
 
+    map.on('load', () => {
+      if (loadingEl) loadingEl.style.display = 'none';
+
+      if (isFinite(data.principal.lon) && isFinite(data.principal.lat)) {
+        new maplibregl.Marker({ color: '#111827' })
+          .setLngLat([data.principal.lon, data.principal.lat])
+          .setPopup(new maplibregl.Popup().setHTML(`<div><b>${data.principal.name}</b><br/>Principal Place</div>`))
+          .addTo(map);
+      }
+
+      populateSecondaries();
+    });
+
     map.on('error', (error) => {
       if (error?.error?.message?.includes('tile')) {
         if (!map._removed && !map.getSource('fallback-satellite')) {
@@ -44,53 +85,59 @@
         }
       }
     });
+  }
 
-    new maplibregl.Marker({ color: '#111827' })
-      .setLngLat([data.principal.lon, data.principal.lat])
-      .setPopup(new maplibregl.Popup().setHTML(`<div><b>${data.principal.name}</b><br/>Principal Place</div>`))
-      .addTo(map);
-
-    // Secondary markers with hover/click interactions
+  function populateSecondaries() {
+    listEl.innerHTML = '';
     data.secondaries.forEach((s) => {
+      if (!isFinite(s.lon) || !isFinite(s.lat)) return;
       const marker = new maplibregl.Marker({ color: '#2563eb' }).setLngLat([s.lon, s.lat]).addTo(map);
+      s._marker = marker;
 
-      const openPanel = () => {
-        currentProject = s;
-        showInfoPanel(s);
-      };
+      const li = document.createElement('li');
+      li.className = 'secondary-item';
+      li.tabIndex = 0;
+      li.innerHTML = `<span>${s.name}</span>` +
+        (s.category ? ` <span class="badge">${s.category}</span>` : '') +
+        (s.footerInfo?.distanceText ? ` <span class="badge">${s.footerInfo.distanceText}</span>` : '') +
+        (s.footerInfo?.timeText ? ` <span class="badge">${s.footerInfo.timeText}</span>` : '') +
+        (s.virtualtour ? ` <span class="badge">3D</span>` : '');
 
-      marker.getElement().addEventListener('mouseenter', openPanel);
-      marker.getElement().addEventListener('click', openPanel);
+      const open = () => openDetails(s);
+      li.addEventListener('click', open);
+      li.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          open();
+        }
+      });
+      li.addEventListener('mouseenter', () => marker.getElement().classList.add('marker-highlight'));
+      li.addEventListener('mouseleave', () => marker.getElement().classList.remove('marker-highlight'));
+      listEl.appendChild(li);
+
+      marker.getElement().addEventListener('mouseenter', () => li.classList.add('hover'));
+      marker.getElement().addEventListener('mouseleave', () => li.classList.remove('hover'));
+      marker.getElement().addEventListener('click', open);
     });
   }
 
-  function showInfoPanel(project) {
-    const panel = document.getElementById('infoPanel');
-    const title = document.getElementById('infoTitle');
-    const container = document.getElementById('panoSmall');
-    const distanceEl = document.getElementById('infoDistance');
-    const timeEl = document.getElementById('infoTime');
-    const meta = document.getElementById('infoMeta');
-
-    title.textContent = project.name;
-    panel.classList.remove('hidden');
-
+  function openDetails(project) {
+    currentProject = project;
+    listView.classList.add('hidden');
+    detailsView.classList.remove('hidden');
+    detailTitle.textContent = project.name;
+    const coordsText = `${project.lat.toFixed(5)}, ${project.lon.toFixed(5)}`;
+    detailCoords.textContent = coordsText;
+    copyBtn.onclick = () => navigator.clipboard.writeText(coordsText);
+    detailDistance.textContent = project.footerInfo?.distanceText || '';
+    detailTime.textContent = project.footerInfo?.timeText || '';
+    detailMedia.innerHTML = '';
     if (viewer && viewer.destroy) {
       viewer.destroy();
       viewer = null;
     }
-    container.innerHTML = '';
-
-    distanceEl.textContent = project.footerInfo?.distanceText || '';
-    timeEl.textContent = project.footerInfo?.timeText || '';
-    if (distanceEl.textContent || timeEl.textContent) {
-      meta.style.display = 'flex';
-    } else {
-      meta.style.display = 'none';
-    }
-
     if (project.virtualtour) {
-      viewer = pannellum.viewer('panoSmall', {
+      viewer = pannellum.viewer('detailMedia', {
         type: 'equirectangular',
         panorama: project.virtualtour,
         crossOrigin: 'anonymous',
@@ -100,78 +147,86 @@
       });
       viewer.on('load', () => viewer.resize());
     }
+    routeToggle.checked = false;
   }
 
-  function hideInfoPanel() {
-    const panel = document.getElementById('infoPanel');
-    panel.classList.add('hidden');
+  function closeDetails() {
+    detailsView.classList.add('hidden');
+    listView.classList.remove('hidden');
+    hideRoute();
     if (viewer && viewer.destroy) {
       viewer.destroy();
       viewer = null;
     }
   }
 
+  function hideRoute() {
+    if (routeLayerId) {
+      if (map.getLayer(routeLayerId)) map.removeLayer(routeLayerId);
+      if (map.getSource(routeLayerId)) map.removeSource(routeLayerId);
+      routeLayerId = null;
+    }
+  }
+
   function showRoute() {
     if (!currentProject) return;
 
-    // Remove existing route
-    if (routeLayerId) {
-      if (map.getLayer(routeLayerId)) map.removeLayer(routeLayerId);
-      if (map.getSource(routeLayerId)) map.removeSource(routeLayerId);
-      routeLayerId = null;
-    }
+    const draw = () => {
+      hideRoute();
+      const route = (currentProject.routes && currentProject.routes[0]) || null;
+      let coords = [];
 
-    const route = (currentProject.routes && currentProject.routes[0]) || null;
-    let feature;
+      if (route && route.geometry && route.geometry.type === 'LineString') {
+        coords = sanitizeLine(route.geometry.coordinates);
+      }
 
-    if (route && route.geometry && route.geometry.type === 'LineString') {
-      feature = { type: 'Feature', properties: {}, geometry: route.geometry };
+      if (coords.length < 2) {
+        coords = [
+          [data.principal.lon, data.principal.lat],
+          [currentProject.lon, currentProject.lat]
+        ];
+      }
+
+      const feature = { type: 'Feature', properties: {}, geometry: { type: 'LineString', coordinates: coords } };
+      const id = `route-${currentProject.id || currentProject.name}`;
+
+      map.addSource(id, { type: 'geojson', data: feature });
+      map.addLayer({
+        id,
+        type: 'line',
+        source: id,
+        layout: { 'line-join': 'round', 'line-cap': 'round' },
+        paint: { 'line-color': '#10b981', 'line-width': 6, 'line-opacity': 0.9 }
+      });
+      routeLayerId = id;
+
+      const bounds = new maplibregl.LngLatBounds();
+      bounds.extend([data.principal.lon, data.principal.lat]);
+      bounds.extend([currentProject.lon, currentProject.lat]);
+      coords.forEach((c) => bounds.extend(c));
+      map.fitBounds(bounds, { padding: 60, maxZoom: 17 });
+    };
+
+    if (!map.loaded()) {
+      map.once('load', draw);
     } else {
-      // fallback straight line
-      feature = {
-        type: 'Feature',
-        properties: {},
-        geometry: {
-          type: 'LineString',
-          coordinates: [
-            [data.principal.lon, data.principal.lat],
-            [currentProject.lon, currentProject.lat]
-          ]
-        }
-      };
+      draw();
     }
-
-    const id = `route-${currentProject.id || currentProject.name}`;
-    map.addSource(id, { type: 'geojson', data: feature });
-    map.addLayer({
-      id,
-      type: 'line',
-      source: id,
-      layout: { 'line-join': 'round', 'line-cap': 'round' },
-      paint: { 'line-color': '#10b981', 'line-width': 6, 'line-opacity': 0.9 }
-    });
-    routeLayerId = id;
-
-    // Fit to exact route geometry (no unintended fly elsewhere)
-    const bounds = new maplibregl.LngLatBounds();
-    feature.geometry.coordinates.forEach(c => bounds.extend(c));
-    map.fitBounds(bounds, { padding: 60, maxZoom: 17 });
   }
 
   function showHome() {
-    hideInfoPanel();
-    if (routeLayerId) {
-      if (map.getLayer(routeLayerId)) map.removeLayer(routeLayerId);
-      if (map.getSource(routeLayerId)) map.removeSource(routeLayerId);
-      routeLayerId = null;
-    }
+    closeDetails();
     map.flyTo({ center: [data.principal.lon, data.principal.lat], zoom: data.principal.zoom || 13, duration: 1000 });
   }
-
   function showAbout() { alert('About Us'); }
   function showProjects() { alert('Projects'); }
   function goHome() { showHome(); }
   function toggleMenu() { alert('Menu'); }
+
+  backBtn.addEventListener('click', closeDetails);
+  routeToggle.addEventListener('change', (e) => {
+    if (e.target.checked) showRoute(); else hideRoute();
+  });
 
   window.onload = function() {
     initMap();
@@ -182,6 +237,4 @@
   window.showProjects = showProjects;
   window.goHome = goHome;
   window.toggleMenu = toggleMenu;
-  window.showRoute = showRoute;
-  window.hideInfoPanel = hideInfoPanel;
 })();

--- a/map-platform-backend/Exports/Project/map.html
+++ b/map-platform-backend/Exports/Project/map.html
@@ -9,6 +9,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/pannellum@2.5.6/build/pannellum.css" />
 </head>
 <body>
+  <div id="loading" class="loading">Loading...</div>
   <!-- Header -->
   <header id="header" class="header">
     <div id="logo" class="logo"><img src="./images/logo.jpg" alt="Untitled Project" class="logo-img" /> <span class="logo-text">Untitled Project</span></div>
@@ -31,21 +32,24 @@
       <div id="map" class="map"></div>
     </div>
 
-    <!-- Right-side info card (hidden by default) -->
-    <aside id="infoPanel" class="info-panel hidden">
-      <div class="info-header">
-        <div id="infoTitle" class="info-title">Place</div>
-        <button class="info-close" onclick="hideInfoPanel()">×</button>
+    <!-- Secondary places sidebar -->
+    <aside id="secondarySidebar" class="secondary-sidebar">
+      <div id="listView">
+        <ul id="secondaryList" class="secondary-list"></ul>
       </div>
-      <div class="info-body">
-        <div id="panoSmall" class="pano-small"></div>
-        <div id="infoMeta" class="info-meta">
-          <span id="infoDistance"></span>
-          <span id="infoTime"></span>
+      <div id="detailsView" class="details-view hidden">
+        <button id="backBtn" class="details-back">Back</button>
+        <h3 id="detailTitle"></h3>
+        <div class="coords">
+          <span id="detailCoords"></span>
+          <button id="copyCoordsBtn">Copy</button>
         </div>
-        <div class="info-actions">
-          <button id="showRouteBtn" class="route-button" onclick="showRoute()">Show Route</button>
+        <div id="detailMedia" class="pano-small"></div>
+        <div id="detailMeta" class="info-meta">
+          <span id="detailDistance"></span>
+          <span id="detailTime"></span>
         </div>
+        <label class="route-toggle"><input type="checkbox" id="routeToggle"> Show route</label>
       </div>
     </aside>
   </div>

--- a/map-platform-backend/src/services/export.service.js
+++ b/map-platform-backend/src/services/export.service.js
@@ -34,6 +34,7 @@ export function buildExportData(doc, { styleURL, profiles = ['driving'] } = {}) 
     if (s.routesFromBase && s.routesFromBase.length) {
       s.routesFromBase.forEach((poly, idx) => {
         const coords = decodePolyline(poly);
+        if (coords.length < 2) return;
         routes.push({
           profile: profiles[idx] || profiles[0] || 'driving',
           distance_m: s.footerInfo?.distance ? parseInt(s.footerInfo.distance.replace(/\D/g, '')) : null,
@@ -79,10 +80,11 @@ export function buildExportData(doc, { styleURL, profiles = ['driving'] } = {}) 
  * Export a project as a static bundle and stream it as a ZIP file.
  * @param {string} projectId
  * @param {{ inlineData?: boolean, includeLocalLibs?: boolean, mirrorImagesLocally?: boolean, styleURL?: string, profiles?: string[] }} options
+ *  inlineData defaults to true to embed project data and avoid file:// CORS issues.
  * @param {import('express').Response} res
  */
 export async function exportProject(projectId, options, res) {
-  const { inlineData = false, includeLocalLibs = true, mirrorImagesLocally = true } = options || {};
+  const { inlineData = true, includeLocalLibs = true, mirrorImagesLocally = true } = options || {};
 
   const doc = await Project.findById(projectId).lean();
   const data = buildExportData(doc, options);

--- a/map-platform-backend/src/templates/app.js
+++ b/map-platform-backend/src/templates/app.js
@@ -1,10 +1,38 @@
 (async function(){
+  const loadingEl = document.getElementById('loading');
   const data = window.__PROJECT__ || await fetch('./data/project.json').then(r=>r.json());
-  
+
   let map;
   let currentProject = null;
   let routeLayerId = null;
   let viewer = null;
+
+  const listView = document.getElementById('listView');
+  const detailsView = document.getElementById('detailsView');
+  const listEl = document.getElementById('secondaryList');
+  const detailTitle = document.getElementById('detailTitle');
+  const detailCoords = document.getElementById('detailCoords');
+  const copyBtn = document.getElementById('copyCoordsBtn');
+  const detailMedia = document.getElementById('detailMedia');
+  const detailDistance = document.getElementById('detailDistance');
+  const detailTime = document.getElementById('detailTime');
+  const routeToggle = document.getElementById('routeToggle');
+  const backBtn = document.getElementById('backBtn');
+
+  function sanitizeLine(coords) {
+    const out = [];
+    coords.forEach((pt) => {
+      if (!Array.isArray(pt) || pt.length < 2) return;
+      let [lon, lat] = pt;
+      if (!isFinite(lon) || !isFinite(lat)) return;
+      if (Math.abs(lon) <= 90 && Math.abs(lat) > 90) {
+        [lon, lat] = [lat, lon];
+      }
+      if (Math.abs(lat) > 90 || Math.abs(lon) > 180) return;
+      out.push([lon, lat]);
+    });
+    return out;
+  }
 
   function initMap() {
     map = new maplibregl.Map({
@@ -31,6 +59,19 @@
 
     map.addControl(new maplibregl.NavigationControl({ visualizePitch: true }));
 
+    map.on('load', () => {
+      if (loadingEl) loadingEl.style.display = 'none';
+
+      if (isFinite(data.principal.lon) && isFinite(data.principal.lat)) {
+        new maplibregl.Marker({ color: '#111827' })
+          .setLngLat([data.principal.lon, data.principal.lat])
+          .setPopup(new maplibregl.Popup().setHTML(`<div><b>${data.principal.name}</b><br/>Principal Place</div>`))
+          .addTo(map);
+      }
+
+      populateSecondaries();
+    });
+
     map.on('error', (error) => {
       if (error?.error?.message?.includes('tile')) {
         if (!map._removed && !map.getSource('fallback-satellite')) {
@@ -44,460 +85,148 @@
         }
       }
     });
+  }
 
-    new maplibregl.Marker({ color: '#111827' })
-      .setLngLat([data.principal.lon, data.principal.lat])
-      .setPopup(new maplibregl.Popup().setHTML(`<div><b>${data.principal.name}</b><br/>Principal Place</div>`))
-      .addTo(map);
-
-    // Secondary markers with click-only interactions
+  function populateSecondaries() {
+    listEl.innerHTML = '';
     data.secondaries.forEach((s) => {
+      if (!isFinite(s.lon) || !isFinite(s.lat)) return;
       const marker = new maplibregl.Marker({ color: '#2563eb' }).setLngLat([s.lon, s.lat]).addTo(map);
+      s._marker = marker;
 
-      const openPanel = () => {
-        currentProject = s;
-        showInfoPanel(s);
-      };
+      const li = document.createElement('li');
+      li.className = 'secondary-item';
+      li.tabIndex = 0;
+      li.innerHTML = `<span>${s.name}</span>` +
+        (s.category ? ` <span class="badge">${s.category}</span>` : '') +
+        (s.footerInfo?.distanceText ? ` <span class="badge">${s.footerInfo.distanceText}</span>` : '') +
+        (s.footerInfo?.timeText ? ` <span class="badge">${s.footerInfo.timeText}</span>` : '') +
+        (s.virtualtour ? ` <span class="badge">3D</span>` : '');
 
-      // Only click event - no hover
-      marker.getElement().addEventListener('click', openPanel);
+      const open = () => openDetails(s);
+      li.addEventListener('click', open);
+      li.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          open();
+        }
+      });
+      li.addEventListener('mouseenter', () => marker.getElement().classList.add('marker-highlight'));
+      li.addEventListener('mouseleave', () => marker.getElement().classList.remove('marker-highlight'));
+      listEl.appendChild(li);
+
+      marker.getElement().addEventListener('mouseenter', () => li.classList.add('hover'));
+      marker.getElement().addEventListener('mouseleave', () => li.classList.remove('hover'));
+      marker.getElement().addEventListener('click', open);
     });
   }
 
-  function showInfoPanel(project) {
-    const panel = document.getElementById('infoPanel');
-    const title = document.getElementById('infoTitle');
-    const container = document.getElementById('panoSmall');
-    const distanceEl = document.getElementById('infoDistance');
-    const timeEl = document.getElementById('infoTime');
-    const meta = document.getElementById('infoMeta');
-
-    // Prevent multiple rapid calls
-    if (panel && panel.classList.contains('loading')) {
-      return;
-    }
-
-    title.textContent = project.name;
-    panel.classList.remove('hidden');
-    panel.classList.add('loading'); // Add loading state
-
+  function openDetails(project) {
+    currentProject = project;
+    listView.classList.add('hidden');
+    detailsView.classList.remove('hidden');
+    detailTitle.textContent = project.name;
+    const coordsText = `${project.lat.toFixed(5)}, ${project.lon.toFixed(5)}`;
+    detailCoords.textContent = coordsText;
+    copyBtn.onclick = () => navigator.clipboard.writeText(coordsText);
+    detailDistance.textContent = project.footerInfo?.distanceText || '';
+    detailTime.textContent = project.footerInfo?.timeText || '';
+    detailMedia.innerHTML = '';
     if (viewer && viewer.destroy) {
-      try {
       viewer.destroy();
-      } catch (e) {
-        console.warn('Error destroying previous viewer:', e);
-      }
       viewer = null;
     }
-    container.innerHTML = '';
-    
-    // Debug logging
-    console.log('Showing info panel for:', project.name);
-    console.log('Virtual tour URL:', project.virtualtour);
-    console.log('Pannellum library available:', typeof pannellum !== 'undefined');
-    console.log('Container element:', container);
-    console.log('Container ID:', container.id);
-
-    distanceEl.textContent = project.footerInfo?.distanceText || '';
-    timeEl.textContent = project.footerInfo?.timeText || '';
-    if (distanceEl.textContent || timeEl.textContent) {
-      meta.style.display = 'flex';
-    } else {
-      meta.style.display = 'none';
-    }
-
     if (project.virtualtour) {
-       // Check if Pannellum is available
-       if (typeof pannellum === 'undefined') {
-         console.error('Pannellum library not loaded');
-         container.innerHTML = '<div style="display: flex; align-items: center; justify-content: center; height: 100%; color: #6b7280; font-size: 14px;">360° viewer not available</div>';
-         return;
-       }
-       
-               // Ensure container exists and is ready
-        if (!container || !container.id) {
-          console.error('Container element not found or invalid');
-          return;
-        }
-        
-        // Check container visibility and dimensions
-        const containerStyle = window.getComputedStyle(container);
-        console.log('Container display:', containerStyle.display);
-        console.log('Container visibility:', containerStyle.visibility);
-        console.log('Container dimensions:', container.offsetWidth, 'x', container.offsetHeight);
-        console.log('Container position:', containerStyle.position);
-        console.log('Container z-index:', containerStyle.zIndex);
-        
-        // Test if the image URL is accessible
-        console.log('Testing image URL accessibility...');
-        const testImg = new Image();
-        testImg.crossOrigin = 'anonymous';
-        testImg.onload = () => {
-          console.log('✅ Image URL is accessible and loads successfully');
-        };
-        testImg.onerror = () => {
-          console.error('❌ Image URL failed to load:', project.virtualtour);
-        };
-        testImg.src = project.virtualtour;
-       
-                               try {
-                  // Clear container completely - don't add placeholder
-                  container.innerHTML = '';
-
-                  // Ensure container has proper dimensions before Pannellum initialization
-                  container.style.height = '220px';
-                  container.style.minHeight = '220px';
-                  container.style.width = '100%';
-
-                  // Small delay to ensure DOM is ready
-                  setTimeout(() => {
-                    // Ensure container is completely clean
-                    container.innerHTML = '';
-                    container.className = 'pano-small';
-                    
-                    container.id = 'panoSmall';
-            try {
-              console.log('Creating Pannellum viewer for container:', container.id);
-              console.log('Container dimensions:', container.offsetWidth, 'x', container.offsetHeight);
-              
-                                                           // Create a simpler Pannellum configuration
-      viewer = pannellum.viewer('panoSmall', {
+      viewer = pannellum.viewer('detailMedia', {
         type: 'equirectangular',
         panorama: project.virtualtour,
         crossOrigin: 'anonymous',
         autoLoad: true,
         showControls: true,
-                hfov: 100,
-                minHfov: 50,
-                maxHfov: 120,
-                showZoomCtrl: true,
-                showFullscreenCtrl: true,
-                showNavCtrl: true,
-                autoRotate: -2,
-                autoRotateInactivityDelay: 2000,
-                autoRotateStopDelay: 2000
-              });
-              
-              console.log('Pannellum viewer created:', viewer);
-              
-              if (viewer) {
-                console.log('Viewer created successfully, setting up event listeners');
-                
-                                 viewer.on('load', () => {
-                   console.log('Pannellum load event fired');
-                   console.log('360° image loaded successfully from:', project.virtualtour);
-                   
-                   // Remove loading state
-                   panel.classList.remove('loading');
-                   
-                   // Force a resize immediately
-                   if (viewer && typeof viewer.resize === 'function') {
-                     console.log('Calling viewer.resize()');
-                     viewer.resize();
-                   }
-                   
-                   // Ensure the container is properly set up
-                   container.style.height = '220px';
-                   container.style.minHeight = '220px';
-                   container.style.width = '100%';
-                   
-                   // Clean up any leftover loading text
-                   const loadingText = container.querySelector('div[style*="Loading 360° viewer"]');
-                   if (loadingText) {
-                     loadingText.remove();
-                   }
-                   
-                   // Log viewer state
-                   console.log('Viewer state after load:', {
-                     isLoaded: viewer.isLoaded(),
-                     getConfig: viewer.getConfig()
-                   });
-                   
-                                       // Force proper canvas dimensions and ensure image loads
-                    setTimeout(() => {
-                      const canvas = container.querySelector('canvas');
-                      if (canvas) {
-                        console.log('Canvas dimensions before fix:', canvas.width, 'x', canvas.height);
-                        
-                        // Force canvas to proper size
-                        canvas.style.height = '100%';
-                        canvas.style.width = '100%';
-                        canvas.height = container.offsetHeight;
-                        canvas.width = container.offsetWidth;
-                        
-                        // Force container dimensions
-                        container.style.height = '220px';
-                        container.style.minHeight = '220px';
-                        
-                        console.log('Canvas dimensions after fix:', canvas.width, 'x', canvas.height);
-                        console.log('Canvas computed style:', window.getComputedStyle(canvas).height);
-                        
-                        // Check if canvas has content
-                        const ctx = canvas.getContext('2d');
-                        const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
-                        const hasContent = imageData.data.some(pixel => pixel !== 0);
-                        console.log('Canvas has content:', hasContent);
-                        
-                        if (!hasContent) {
-                          console.warn('Canvas appears to be empty, forcing image reload');
-                          // Try to reload the panorama
-                          if (viewer && typeof viewer.loadScene === 'function') {
-                            viewer.loadScene({
-                              type: 'equirectangular',
-                              panorama: project.virtualtour
-                            });
-                          }
-                        }
-                      }
-                      
-                      if (viewer && typeof viewer.resize === 'function') {
-                        console.log('Calling viewer.resize() after canvas fix');
-                        viewer.resize();
-                      }
-                    }, 100);
-                   
-                                           // Additional resize after a longer delay
-                        setTimeout(() => {
-                          if (viewer && typeof viewer.resize === 'function') {
-                            console.log('Final viewer.resize() call');
-                            viewer.resize();
-                          }
-                          
-                          // Continuously monitor and fix canvas height
-                          const fixCanvasHeight = () => {
-                            const canvas = container.querySelector('canvas');
-                            if (canvas && canvas.style.height !== '100%') {
-                              console.log('Fixing canvas height to 100%');
-                              canvas.style.height = '100%';
-                              canvas.style.minHeight = '100%';
-                              canvas.style.maxHeight = 'none';
-                            }
-                          };
-                          
-                          // Check every 500ms for 5 seconds
-                          let checkCount = 0;
-                          const heightCheckInterval = setInterval(() => {
-                            fixCanvasHeight();
-                            checkCount++;
-                            if (checkCount >= 10) {
-                              clearInterval(heightCheckInterval);
-                            }
-                          }, 500);
-                     
-                                           // Final canvas dimension check and fix
-                      const canvas = container.querySelector('canvas');
-                      if (canvas && canvas.height < 200) {
-                        console.log('Canvas still too small, forcing dimensions again');
-                        canvas.height = container.offsetHeight;
-                        canvas.width = container.offsetWidth;
-                        canvas.style.height = '100%';
-                        canvas.style.width = '100%';
-                        
-                        if (viewer && typeof viewer.resize === 'function') {
-                          viewer.resize();
-                        }
-                      }
-                      
-                      // Check if the image is actually visible
-                      const ctx = canvas.getContext('2d');
-                      const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
-                      const hasVisibleContent = imageData.data.some((pixel, index) => {
-                        // Check for non-transparent pixels (every 4th value is alpha)
-                        return index % 4 === 3 && pixel > 0;
-                      });
-                      console.log('Canvas has visible content after 500ms:', hasVisibleContent);
-                      
-                      if (!hasVisibleContent) {
-                        console.warn('Canvas still appears empty, trying alternative approach');
-                        // Try to force a complete reload
-                        if (viewer && typeof viewer.destroy === 'function') {
-                          viewer.destroy();
-                          setTimeout(() => {
-                            viewer = pannellum.viewer('panoSmall', {
-                              type: 'equirectangular',
-                              panorama: project.virtualtour,
-                              crossOrigin: 'anonymous',
-                              autoLoad: true,
-                              showControls: true
-                            });
-                          }, 100);
-                        }
-                      }
-                   }, 500);
-                 });
-                
-                                        viewer.on('error', (error) => {
-                          console.error('360° image failed to load:', error);
-                          container.innerHTML = '<div style="display: flex; align-items: center; justify-content: center; height: 100%; color: #6b7280; font-size: 14px;">360° image not available</div>';
-                          panel.classList.remove('loading'); // Remove loading state on error
-                        });
+        hfov: 100
+      });
+      viewer.on('load', () => viewer.resize());
+    }
+    routeToggle.checked = false;
+  }
 
-                        // Handle fullscreen toggle
-                        viewer.on('fullscreenchange', (isFullscreen) => {
-                          console.log('Fullscreen changed:', isFullscreen);
-                          if (isFullscreen) {
-                            // Force fullscreen dimensions
-                            const fullscreenContainer = document.querySelector('.pnlm-fullscreen');
-                            if (fullscreenContainer) {
-                              fullscreenContainer.style.width = '100vw';
-                              fullscreenContainer.style.height = '100vh';
-                              fullscreenContainer.style.minHeight = '100vh';
-                              
-                              const fullscreenCanvas = fullscreenContainer.querySelector('canvas');
-                              if (fullscreenCanvas) {
-                                fullscreenCanvas.style.width = '100%';
-                                fullscreenCanvas.style.height = '100%';
-                                fullscreenCanvas.style.minHeight = '100vh';
-                              }
-                              
-                              // Force resize after a short delay
-                              setTimeout(() => {
-                                if (viewer && typeof viewer.resize === 'function') {
-                                  viewer.resize();
-                                }
-                              }, 100);
-                            }
-                          }
-                        });
-
-                        // Add manual fullscreen handling as fallback
-                        const fullscreenButton = container.querySelector('.pnlm-fullscreen-toggle-button');
-                        if (fullscreenButton) {
-                          fullscreenButton.addEventListener('click', () => {
-                            setTimeout(() => {
-                              const fullscreenContainer = document.querySelector('.pnlm-fullscreen');
-                              if (fullscreenContainer) {
-                                console.log('Manual fullscreen fix applied');
-                                fullscreenContainer.style.width = '100vw';
-                                fullscreenContainer.style.height = '100vh';
-                                fullscreenContainer.style.minHeight = '100vh';
-                                fullscreenContainer.style.position = 'fixed';
-                                fullscreenContainer.style.top = '0';
-                                fullscreenContainer.style.left = '0';
-                                fullscreenContainer.style.zIndex = '9999';
-                                
-                                const canvas = fullscreenContainer.querySelector('canvas');
-                                if (canvas) {
-                                  canvas.style.width = '100%';
-                                  canvas.style.height = '100%';
-                                  canvas.style.minHeight = '100vh';
-                                }
-                                
-                                if (viewer && typeof viewer.resize === 'function') {
-                                  viewer.resize();
-                                }
-                              }
-                            }, 50);
-                          });
-                        }
-                
-                // Add a timeout to check if the viewer is actually rendering
-                setTimeout(() => {
-                  const canvas = container.querySelector('canvas');
-                  if (!canvas) {
-                    console.warn('No canvas found in container after viewer creation');
-                    container.innerHTML = '<div style="display: flex; align-items: center; justify-content: center; height: 100%; color: #6b7280; font-size: 14px;">360° viewer not rendering</div>';
-                    panel.classList.remove('loading');
-                  } else {
-                    console.log('Canvas found in container:', canvas);
-                  }
-                }, 1000);
-              } else {
-                console.error('Failed to create Pannellum viewer');
-                container.innerHTML = '<div style="display: flex; align-items: center; justify-content: center; height: 100%; color: #6b7280; font-size: 14px;">360° viewer creation failed</div>';
-                panel.classList.remove('loading'); // Remove loading state on failure
-              }
-            } catch (viewerError) {
-              console.error('Error creating Pannellum viewer:', viewerError);
-              container.innerHTML = '<div style="display: flex; align-items: center; justify-content: center; height: 100%; color: #6b7280; font-size: 14px;">360° viewer error</div>';
-              panel.classList.remove('loading'); // Remove loading state on error
-            }
-          }, 200); // Increased delay to ensure DOM is fully ready
-                } catch (error) {
-           console.error('Failed to initialize 360° viewer:', error);
-           container.innerHTML = '<div style="display: flex; align-items: center; justify-content: center; height: 100%; color: #6b7280; font-size: 14px;">360° image not available</div>';
-           panel.classList.remove('loading'); // Remove loading state on error
-         }
-         } else {
-       container.innerHTML = '<div style="display: flex; align-items: center; justify-content: center; height: 100%; color: #6b7280; font-size: 14px;">No 360° image available</div>';
-       panel.classList.remove('loading'); // Remove loading state when no image
+  function closeDetails() {
+    detailsView.classList.add('hidden');
+    listView.classList.remove('hidden');
+    hideRoute();
+    if (viewer && viewer.destroy) {
+      viewer.destroy();
+      viewer = null;
     }
   }
 
-  function hideInfoPanel() {
-    const panel = document.getElementById('infoPanel');
-    panel.classList.add('hidden');
-    if (viewer && viewer.destroy) {
-      try {
-      viewer.destroy();
-      } catch (e) {
-        console.warn('Error destroying viewer:', e);
-      }
-      viewer = null;
+  function hideRoute() {
+    if (routeLayerId) {
+      if (map.getLayer(routeLayerId)) map.removeLayer(routeLayerId);
+      if (map.getSource(routeLayerId)) map.removeSource(routeLayerId);
+      routeLayerId = null;
     }
   }
 
   function showRoute() {
     if (!currentProject) return;
 
-    // Remove existing route
-    if (routeLayerId) {
-      if (map.getLayer(routeLayerId)) map.removeLayer(routeLayerId);
-      if (map.getSource(routeLayerId)) map.removeSource(routeLayerId);
-      routeLayerId = null;
-    }
+    const draw = () => {
+      hideRoute();
+      const route = (currentProject.routes && currentProject.routes[0]) || null;
+      let coords = [];
 
-    const route = (currentProject.routes && currentProject.routes[0]) || null;
-    let feature;
+      if (route && route.geometry && route.geometry.type === 'LineString') {
+        coords = sanitizeLine(route.geometry.coordinates);
+      }
 
-    if (route && route.geometry && route.geometry.type === 'LineString') {
-      feature = { type: 'Feature', properties: {}, geometry: route.geometry };
+      if (coords.length < 2) {
+        coords = [
+          [data.principal.lon, data.principal.lat],
+          [currentProject.lon, currentProject.lat]
+        ];
+      }
+
+      const feature = { type: 'Feature', properties: {}, geometry: { type: 'LineString', coordinates: coords } };
+      const id = `route-${currentProject.id || currentProject.name}`;
+
+      map.addSource(id, { type: 'geojson', data: feature });
+      map.addLayer({
+        id,
+        type: 'line',
+        source: id,
+        layout: { 'line-join': 'round', 'line-cap': 'round' },
+        paint: { 'line-color': '#10b981', 'line-width': 6, 'line-opacity': 0.9 }
+      });
+      routeLayerId = id;
+
+      const bounds = new maplibregl.LngLatBounds();
+      bounds.extend([data.principal.lon, data.principal.lat]);
+      bounds.extend([currentProject.lon, currentProject.lat]);
+      coords.forEach((c) => bounds.extend(c));
+      map.fitBounds(bounds, { padding: 60, maxZoom: 17 });
+    };
+
+    if (!map.loaded()) {
+      map.once('load', draw);
     } else {
-      // fallback straight line
-      feature = {
-        type: 'Feature',
-        properties: {},
-        geometry: {
-          type: 'LineString',
-          coordinates: [
-            [data.principal.lon, data.principal.lat],
-            [currentProject.lon, currentProject.lat]
-          ]
-        }
-      };
+      draw();
     }
-
-    const id = `route-${currentProject.id || currentProject.name}`;
-    map.addSource(id, { type: 'geojson', data: feature });
-    map.addLayer({
-      id,
-      type: 'line',
-      source: id,
-      layout: { 'line-join': 'round', 'line-cap': 'round' },
-      paint: { 'line-color': '#10b981', 'line-width': 6, 'line-opacity': 0.9 }
-    });
-    routeLayerId = id;
-
-    // Fit to exact route geometry (no unintended fly elsewhere)
-    const bounds = new maplibregl.LngLatBounds();
-    feature.geometry.coordinates.forEach(c => bounds.extend(c));
-    map.fitBounds(bounds, { padding: 60, maxZoom: 17 });
   }
 
   function showHome() {
-    hideInfoPanel();
-    if (routeLayerId) {
-      if (map.getLayer(routeLayerId)) map.removeLayer(routeLayerId);
-      if (map.getSource(routeLayerId)) map.removeSource(routeLayerId);
-      routeLayerId = null;
-    }
+    closeDetails();
     map.flyTo({ center: [data.principal.lon, data.principal.lat], zoom: data.principal.zoom || 13, duration: 1000 });
   }
-
   function showAbout() { alert('About Us'); }
   function showProjects() { alert('Projects'); }
   function goHome() { showHome(); }
   function toggleMenu() { alert('Menu'); }
+
+  backBtn.addEventListener('click', closeDetails);
+  routeToggle.addEventListener('change', (e) => {
+    if (e.target.checked) showRoute(); else hideRoute();
+  });
 
   window.onload = function() {
     initMap();
@@ -508,6 +237,4 @@
   window.showProjects = showProjects;
   window.goHome = goHome;
   window.toggleMenu = toggleMenu;
-  window.showRoute = showRoute;
-  window.hideInfoPanel = hideInfoPanel;
 })();

--- a/map-platform-backend/src/templates/map.html
+++ b/map-platform-backend/src/templates/map.html
@@ -8,6 +8,7 @@
   {{LIB_STYLES}}
 </head>
 <body>
+  <div id="loading" class="loading">Loading...</div>
   <!-- Header -->
   <header id="header" class="header">
     <div id="logo" class="logo">{{HEADER_LOGO}}</div>
@@ -30,21 +31,24 @@
       <div id="map" class="map"></div>
     </div>
 
-    <!-- Right-side info card (hidden by default) -->
-    <aside id="infoPanel" class="info-panel hidden">
-      <div class="info-header">
-        <div id="infoTitle" class="info-title">Place</div>
-        <button class="info-close" onclick="hideInfoPanel()">×</button>
+    <!-- Secondary places sidebar -->
+    <aside id="secondarySidebar" class="secondary-sidebar">
+      <div id="listView">
+        <ul id="secondaryList" class="secondary-list"></ul>
       </div>
-      <div class="info-body">
-        <div id="panoSmall" class="pano-small"></div>
-        <div id="infoMeta" class="info-meta">
-          <span id="infoDistance"></span>
-          <span id="infoTime"></span>
+      <div id="detailsView" class="details-view hidden">
+        <button id="backBtn" class="details-back">Back</button>
+        <h3 id="detailTitle"></h3>
+        <div class="coords">
+          <span id="detailCoords"></span>
+          <button id="copyCoordsBtn">Copy</button>
         </div>
-        <div class="info-actions">
-          <button id="showRouteBtn" class="route-button" onclick="showRoute()">Show Route</button>
+        <div id="detailMedia" class="pano-small"></div>
+        <div id="detailMeta" class="info-meta">
+          <span id="detailDistance"></span>
+          <span id="detailTime"></span>
         </div>
+        <label class="route-toggle"><input type="checkbox" id="routeToggle"> Show route</label>
       </div>
     </aside>
   </div>

--- a/map-platform-backend/src/templates/styles.css
+++ b/map-platform-backend/src/templates/styles.css
@@ -11,6 +11,19 @@ body {
   overflow: hidden;
 }
 
+#loading {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #ffffff;
+  z-index: 2000;
+}
+
 /* Header Styles */
 .header {
   position: fixed;
@@ -270,173 +283,88 @@ body {
   }
 }
 
-/* Info Panel (right side) */
-.info-panel {
-  position: fixed;
-  top: 80px;
-  right: 16px;
-  width: 360px;
-  max-height: calc(100vh - 100px);
-  background: rgba(255,255,255,0.98);
-  box-shadow: 0 10px 30px rgba(0,0,0,0.2);
-  border-radius: 16px;
-  overflow: hidden;
-  z-index: 1200;
+/* Secondary places sidebar */
+.secondary-sidebar {
+  width: 320px;
+  background: rgba(255,255,255,0.95);
+  backdrop-filter: blur(10px);
+  border-left: 1px solid rgba(0,0,0,0.1);
+  overflow-y: auto;
+  z-index: 100;
   display: flex;
   flex-direction: column;
-  transition: all 0.3s ease;
 }
 
-.info-panel.loading {
-  opacity: 0.8;
-  pointer-events: none;
+.secondary-list {
+  list-style: none;
+  padding: 10px;
 }
-.hidden { display: none; }
 
-.info-header {
+.secondary-item {
+  padding: 8px;
+  border-bottom: 1px solid #e5e7eb;
+  cursor: pointer;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+
+.secondary-item:hover,
+.secondary-item:focus {
+  background: #f3f4f6;
+  outline: none;
+}
+
+.badge {
+  background: #e5e7eb;
+  border-radius: 4px;
+  padding: 2px 4px;
+  font-size: 12px;
+  line-height: 1;
+}
+
+.details-view {
+  padding: 12px;
+}
+
+.details-back {
+  margin-bottom: 8px;
+}
+
+.coords {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  padding: 12px 14px;
-  background: #111827;
-  color: #fff;
-}
-.info-title { font-size: 16px; font-weight: 600; }
-.info-close { background:none; border:none; color:#fff; font-size:22px; cursor:pointer; }
-
-.info-body { padding: 12px; }
-.pano-small { 
-  width: 100%; 
-  height: 100%; 
-  background: #f3f4f6; 
-  border-radius: 10px; 
-  overflow: hidden; 
-  position: relative;
+  gap: 6px;
+  font-size: 14px;
+  margin-bottom: 10px;
 }
 
-/* Pannellum container styles */
-.pano-small .pannellum-container {
-  width: 100% !important;
-  height: 100% !important;
-  min-height: 100% !important;
-  border-radius: 10px !important;
-  position: relative !important;
-  display: block !important;
+.marker-highlight {
+  transform: scale(1.4);
 }
 
-/* Pannellum viewer specific styles */
-.pano-small .pannellum-container canvas {
-  border-radius: 10px !important;
-  height: 100% !important;
-  width: 100% !important;
-  min-height: 100% !important;
-  max-height: none !important;
-  display: block !important;
-}
+.pano-small { width: 100%; height: 220px; background: #f3f4f6; border-radius: 10px; overflow: hidden; }
+.info-meta { margin-top: 8px; font-size: 14px; color: #4b5563; display: flex; gap: 8px; }
 
-/* Override any inline styles that Pannellum sets */
-.pano-small .pannellum-container canvas[style*="height"] {
-  height: 100% !important;
-  min-height: 100% !important;
-  max-height: none !important;
-}
+@media (max-width: 768px) {
+  .secondary-sidebar {
+    width: 100%;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 40%;
+    border-left: none;
+    border-top: 1px solid rgba(0,0,0,0.1);
+  }
 
-/* Ensure Pannellum UI elements are properly positioned */
-.pano-small .pnlm-ui {
-  border-radius: 10px !important;
-}
-
-.pano-small .pnlm-render-container {
-  border-radius: 10px !important;
-  height: 100% !important;
-  width: 100% !important;
-  min-height: 100% !important;
-}
-
-.pano-small .pannellum-container .pnlm-controls-container {
-  border-radius: 10px;
-}
-
-/* Ensure proper z-index for controls */
-.pano-small .pannellum-container .pnlm-controls {
-  z-index: 1000;
-}
-
-/* Fullscreen styles for Pannellum */
-.pnlm-fullscreen {
-  position: fixed !important;
-  top: 0 !important;
-  left: 0 !important;
-  width: 100vw !important;
-  height: 100vh !important;
-  z-index: 9999 !important;
-  background: #000 !important;
-}
-
-.pnlm-fullscreen .pannellum-container {
-  width: 100% !important;
-  height: 100% !important;
-  min-height: 100vh !important;
-  border-radius: 0 !important;
-}
-
-.pnlm-fullscreen .pannellum-container canvas {
-  width: 100% !important;
-  height: 100% !important;
-  min-height: 100vh !important;
-  border-radius: 0 !important;
-}
-
-.pnlm-fullscreen .pnlm-render-container {
-  width: 100% !important;
-  height: 100% !important;
-  min-height: 100vh !important;
-  border-radius: 0 !important;
-}
-
-.pnlm-fullscreen .pnlm-ui {
-  border-radius: 0 !important;
-}
-
-/* Ensure fullscreen controls are visible */
-.pnlm-fullscreen .pnlm-controls-container {
-  z-index: 10000 !important;
-}
-
-/* Fullscreen toggle button styles */
-.pnlm-fullscreen-toggle-button {
-  cursor: pointer !important;
-  z-index: 10001 !important;
-}
-
-/* Additional fullscreen fixes */
-.pnlm-fullscreen .pannellum-container {
-  position: absolute !important;
-  top: 0 !important;
-  left: 0 !important;
-  right: 0 !important;
-  bottom: 0 !important;
-}
-
-/* Fix for browsers that don't support fullscreen properly */
-@media screen and (max-width: 100vw) {
-  .pnlm-fullscreen {
-    width: 100vw !important;
-    height: 100vh !important;
+  .main-container {
+    padding-bottom: 40%;
   }
 }
 
-/* Make markers look clickable */
-.maplibregl-marker {
-  cursor: pointer;
-  transition: transform 0.2s ease;
-}
-
-.maplibregl-marker:hover {
-  transform: scale(1.1);
-}
-.info-meta { margin-top: 8px; font-size: 14px; color: #4b5563; display: flex; gap: 8px; }
-.info-actions { display:flex; justify-content:flex-end; margin-top: 10px; }
+.hidden { display: none; }
 
 /* Hide legacy elements if any remain */
-.sidebar, .modal-overlay { display: none !important; }
+.modal-overlay { display: none !important; }

--- a/map-platform-frontend/app/page.tsx
+++ b/map-platform-frontend/app/page.tsx
@@ -462,7 +462,16 @@ function decodePolylineToGeoJSON(maplibregl, encoded) {
       do { b = str.charCodeAt(index++) - 63; result |= (b & 0x1f) << shift; shift += 5; } while (b >= 0x20);
       const dlng = ((result & 1) ? ~(result >> 1) : (result >> 1));
       lng += dlng;
-      coordinates.push([lng * 1e-5, lat * 1e-5]);
+      const lon = lng * 1e-5;
+      const latVal = lat * 1e-5;
+      // guard invalid numbers
+      if (!isFinite(lon) || !isFinite(latVal)) continue;
+      // ensure [lon, lat] order, flip if clearly swapped
+      let pair = [lon, latVal];
+      if (Math.abs(lon) <= 90 && Math.abs(latVal) > 90) {
+        pair = [latVal, lon];
+      }
+      coordinates.push(pair);
     }
     return coordinates;
   }
@@ -473,6 +482,22 @@ function decodePolylineToGeoJSON(maplibregl, encoded) {
     geometry: { type: 'LineString', coordinates: coords },
     properties: {}
   };
+}
+
+function sanitizeLineCoords(coords) {
+  const cleaned = [];
+  coords.forEach((pt) => {
+    if (!Array.isArray(pt) || pt.length < 2) return;
+    let [lon, lat] = pt;
+    if (!isFinite(lon) || !isFinite(lat)) return;
+    // if values look flipped ([lat, lon]), swap
+    if (Math.abs(lon) <= 90 && Math.abs(lat) > 90) {
+      [lon, lat] = [lat, lon];
+    }
+    if (Math.abs(lat) > 90 || Math.abs(lon) > 180) return;
+    cleaned.push([lon, lat]);
+  });
+  return cleaned;
 }
 
 // Helper function to generate intermediate waypoints for realistic car routing
@@ -812,121 +837,140 @@ function MapCanvas() {
 
   // draw markers & routes on updates
   useEffect(() => {
-    if (!ready || !mapInstance || !maplibregl) return;
+    if (!mapInstance || !maplibregl) return;
 
-    // Clean previous markers
-    if (!mapInstance.__markers) mapInstance.__markers = [];
-    mapInstance.__markers.forEach((mk) => mk.remove());
-    mapInstance.__markers = [];
+    const draw = () => {
+      // Clean previous markers
+      if (!mapInstance.__markers) mapInstance.__markers = [];
+      mapInstance.__markers.forEach((mk) => mk.remove());
+      mapInstance.__markers = [];
 
-    // Principal marker
-    const p = project.principal;
-    const pm = new maplibregl.Marker({ color: '#111827' })
-      .setLngLat([p.longitude, p.latitude])
-      .setPopup(new maplibregl.Popup().setHTML(`<div class="text-sm"><b>${p.name}</b><br/>${prettyLatLng(p.latitude, p.longitude)}</div>`))
-      .addTo(mapInstance);
-    mapInstance.__markers.push(pm);
-
-    // Secondary markers
-    project.secondaries.forEach((s, idx) => {
-      const mk = new maplibregl.Marker({ color: '#2563eb' })
-        .setLngLat([s.longitude, s.latitude])
-        .setPopup(new maplibregl.Popup().setHTML(`
-          <div class="text-sm">
-            <b>${s.name}</b><br/>${prettyLatLng(s.latitude, s.longitude)}<br/>
-            ${s.footerInfo?.distance ? `Distance: ${s.footerInfo.distance}<br/>` : ''}
-            ${s.footerInfo?.time ? `Time: ${s.footerInfo.time}` : ''}
-          </div>`))
-        .addTo(mapInstance);
-      mapInstance.__markers.push(mk);
-    });
-
-    // Routes: remove existing layers/sources (ensure layers removed before sources)
-    const routeIds = (mapInstance.__routeIds || []);
-    routeIds.forEach((id) => {
-      const outlineId = `${id}-outline`;
-      if (mapInstance.getLayer(outlineId)) mapInstance.removeLayer(outlineId);
-      if (mapInstance.getLayer(id)) mapInstance.removeLayer(id);
-      if (mapInstance.getSource(id)) mapInstance.removeSource(id);
-    });
-    mapInstance.__routeIds = [];
-
-    // Draw routes if present
-    project.secondaries.forEach((s, idx) => {
-      const encoded = s.routesFromBase?.[0];
-      if (!encoded) return;
-      
-      console.log(`Rendering route for ${s.name}:`, {
-        hasRouteGeoJSON: !!s.routeGeoJSON,
-        routeGeoJSON: s.routeGeoJSON,
-        encoded: encoded
-      });
-      
-      try {
-        let feature;
-        let routeId = `route-${idx}`;
-        
-        // Check if we have GeoJSON data (from routing API)
-        if (s.routeGeoJSON) {
-          // Use the actual GeoJSON route data
-          feature = s.routeGeoJSON;
-          console.log(`Using GeoJSON route data for ${s.name}:`, feature);
-        } else {
-          // Fallback to polyline decoding
-          feature = decodePolylineToGeoJSON(maplibregl, encoded);
-          console.log(`Using decoded polyline route for ${s.name}:`, feature);
-        }
-        
-        // Remove existing route layer if it exists
-        if (mapInstance.getLayer(routeId)) {
-          mapInstance.removeLayer(routeId);
-        }
-        if (mapInstance.getSource(routeId)) {
-          mapInstance.removeSource(routeId);
-        }
-        
-        // Add new route layer with enhanced styling
-        mapInstance.addSource(routeId, { type: 'geojson', data: feature });
-        mapInstance.addLayer({
-          id: routeId,
-          type: 'line',
-          source: routeId,
-          paint: { 
-            'line-width': 6, 
-            'line-color': '#10b981',
-            'line-opacity': 0.9
-          },
-          layout: {
-            'line-join': 'round',
-            'line-cap': 'round'
-          }
-        });
-        
-        // Add a subtle outline for better visibility
-        mapInstance.addLayer({
-          id: `${routeId}-outline`,
-          type: 'line',
-          source: routeId,
-          paint: { 
-            'line-width': 8, 
-            'line-color': '#ffffff',
-            'line-opacity': 0.3
-          },
-          layout: {
-            'line-join': 'round',
-            'line-cap': 'round'
-          }
-        }, routeId); // Insert below the main route line
-        
-        // Track base route IDs so we can clean layers/sources safely later
-        mapInstance.__routeIds.push(routeId);
-        
-        console.log(`Route ${idx} added to map:`, feature);
-      } catch (error) {
-        console.error(`Failed to render route ${idx}:`, error);
+      // Principal marker
+      const p = project.principal;
+      if (isFinite(p.longitude) && isFinite(p.latitude)) {
+        const pm = new maplibregl.Marker({ color: '#111827' })
+          .setLngLat([p.longitude, p.latitude])
+          .setPopup(new maplibregl.Popup().setHTML(`<div class="text-sm"><b>${p.name}</b><br/>${prettyLatLng(p.latitude, p.longitude)}</div>`))
+          .addTo(mapInstance);
+        mapInstance.__markers.push(pm);
       }
-    });
-  }, [project, mapInstance, maplibregl, ready]);
+
+      // Secondary markers
+      project.secondaries.forEach((s, idx) => {
+        if (!isFinite(s.longitude) || !isFinite(s.latitude)) return;
+        const mk = new maplibregl.Marker({ color: '#2563eb' })
+          .setLngLat([s.longitude, s.latitude])
+          .setPopup(new maplibregl.Popup().setHTML(`
+            <div class="text-sm">
+              <b>${s.name}</b><br/>${prettyLatLng(s.latitude, s.longitude)}<br/>
+              ${s.footerInfo?.distance ? `Distance: ${s.footerInfo.distance}<br/>` : ''}
+              ${s.footerInfo?.time ? `Time: ${s.footerInfo.time}` : ''}
+            </div>`))
+          .addTo(mapInstance);
+        mapInstance.__markers.push(mk);
+      });
+
+      // Routes: remove existing layers/sources (ensure layers removed before sources)
+      const routeIds = (mapInstance.__routeIds || []);
+      routeIds.forEach((id) => {
+        const outlineId = `${id}-outline`;
+        if (mapInstance.getLayer(outlineId)) mapInstance.removeLayer(outlineId);
+        if (mapInstance.getLayer(id)) mapInstance.removeLayer(id);
+        if (mapInstance.getSource(id)) mapInstance.removeSource(id);
+      });
+      mapInstance.__routeIds = [];
+
+      // Draw routes if present
+      project.secondaries.forEach((s, idx) => {
+        const encoded = s.routesFromBase?.[0];
+        if (!encoded) return;
+
+        console.log(`Rendering route for ${s.name}:`, {
+          hasRouteGeoJSON: !!s.routeGeoJSON,
+          routeGeoJSON: s.routeGeoJSON,
+          encoded: encoded
+        });
+
+        try {
+          let feature;
+          let routeId = `route-${idx}`;
+
+          // Check if we have GeoJSON data (from routing API)
+          if (s.routeGeoJSON) {
+            feature = s.routeGeoJSON;
+            console.log(`Using GeoJSON route data for ${s.name}:`, feature);
+          } else {
+            feature = decodePolylineToGeoJSON(maplibregl, encoded);
+            console.log(`Using decoded polyline route for ${s.name}:`, feature);
+          }
+
+          if (feature?.geometry?.type === 'LineString') {
+            feature = {
+              ...feature,
+              geometry: {
+                ...feature.geometry,
+                coordinates: sanitizeLineCoords(feature.geometry.coordinates)
+              }
+            };
+          }
+
+          if (!feature.geometry.coordinates.length) return;
+
+          // Remove existing route layer if it exists
+          if (mapInstance.getLayer(routeId)) {
+            mapInstance.removeLayer(routeId);
+          }
+          if (mapInstance.getSource(routeId)) {
+            mapInstance.removeSource(routeId);
+          }
+
+          // Add new route layer with enhanced styling
+          mapInstance.addSource(routeId, { type: 'geojson', data: feature });
+          mapInstance.addLayer({
+            id: routeId,
+            type: 'line',
+            source: routeId,
+            paint: {
+              'line-width': 6,
+              'line-color': '#10b981',
+              'line-opacity': 0.9
+            },
+            layout: {
+              'line-join': 'round',
+              'line-cap': 'round'
+            }
+          });
+
+          mapInstance.addLayer({
+            id: `${routeId}-outline`,
+            type: 'line',
+            source: routeId,
+            paint: {
+              'line-width': 8,
+              'line-color': '#ffffff',
+              'line-opacity': 0.3
+            },
+            layout: {
+              'line-join': 'round',
+              'line-cap': 'round'
+            }
+          }, routeId); // Insert below the main route line
+
+          mapInstance.__routeIds.push(routeId);
+
+          console.log(`Route ${idx} added to map:`, feature);
+        } catch (error) {
+          console.error(`Failed to render route ${idx}:`, error);
+        }
+      });
+    };
+
+    if (mapInstance.isStyleLoaded()) {
+      draw();
+    } else {
+      mapInstance.once('load', draw);
+    }
+  }, [project, mapInstance, maplibregl]);
 
   return (
     <div ref={mapRef} className="w-full h-full rounded-2xl overflow-hidden bg-gray-200" style={{ position: 'relative' }}>
@@ -1141,7 +1185,7 @@ export default function MappingStudio() {
   const [exporting, setExporting] = useState(false);
   const [expOpts, setExpOpts] = useState({
     mirrorImagesLocally: true,
-    inlineData: false,
+    inlineData: true,
     includeLocalLibs: true,
     styleURL: 'satellite',
     profiles: ['driving'],


### PR DESCRIPTION
## Summary
- Sanitize decoded polylines and route data to enforce `[lon, lat]` ordering and skip invalid points
- Defer marker and route layer creation until the map style has loaded
- Fit bounds to principal and secondary markers when showing routes
- Embed secondary places sidebar with list and details views for route highlighting

## Testing
- `npm test` (backend) *(fails: Cannot find package 'polyline' or 'archiver')*
- `npm run lint` (backend) *(fails: ESLint config file missing)*
- `npm test` (frontend) *(fails: Missing script 'test')*
- `npm run lint` (frontend) *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b22dc448448324b38f9e6ad5f4e84b