### PR TITLE
feat: add offline fallback for 3D model uploads

### DIFF
--- a/map-platform-frontend/app/page.tsx
+++ b/map-platform-frontend/app/page.tsx
@@ -170,23 +170,28 @@ async function uploadImage(file) {
 
 async function upload3DModel(file) {
   const backend = useStudio.getState().backend;
-  
+
   try {
     const fd = new FormData();
     fd.append('file', file);
     const res = await fetch(`${backend}/api/upload/3d-model`, { method: 'POST', body: fd });
-    
+
     if (!res.ok) {
       throw new Error('3D model upload failed');
     }
-    
+
     const result = await res.json();
     // Convert relative URL to absolute URL
     result.url = `${backend}${result.url}`;
     return result;
   } catch (error) {
-    console.error('3D model upload failed:', error);
-    throw error;
+    // Network error or backend not running — fallback to mock response
+    console.warn('3D model upload failed, using mock response:', error.message);
+    return {
+      url: URL.createObjectURL(file),
+      public_id: `mock-3d-${Date.now()}`,
+      bytes: file.size
+    };
   }
 }
 


### PR DESCRIPTION
## Summary
- add mock 3D model upload response when backend unreachable

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next not found; npm install forbidden 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b30fe6e178832491d179e54dec8276