### PR TITLE
Clamp exported map max zoom to available tiles

### DIFF
--- a/map-platform-backend/Exports/Project/assets/js/app.js
+++ b/map-platform-backend/Exports/Project/assets/js/app.js
@@ -309,16 +309,37 @@
               }
             },
             layers: [
-              { id: 'satellite-layer', type: 'raster', source: 'satellite', minzoom: 0, maxzoom: 22 }
+              { id: 'satellite-layer', type: 'raster', source: 'satellite', minzoom: 0, maxzoom: 19 }
             ]
           };
+
+    const deriveStyleMaxZoom = (styleDefinition) => {
+      if (!styleDefinition || typeof styleDefinition === 'string') {
+        return undefined;
+      }
+      if (!Array.isArray(styleDefinition.layers)) {
+        return undefined;
+      }
+      const zoomLevels = styleDefinition.layers
+        .map((layer) => (typeof layer.maxzoom === 'number' ? layer.maxzoom : undefined))
+        .filter((value) => Number.isFinite(value));
+      if (!zoomLevels.length) {
+        return undefined;
+      }
+      return Math.max(...zoomLevels);
+    };
+
+    const DEFAULT_TILE_MAX_ZOOM = 19;
+    const styleMaxZoom = deriveStyleMaxZoom(style) ?? DEFAULT_TILE_MAX_ZOOM;
+    const projectMaxZoom = Number.isFinite(data.project?.maxZoom) ? data.project.maxZoom : styleMaxZoom;
+    const mapMaxZoom = Math.min(projectMaxZoom, styleMaxZoom);
 
     map = new maplibregl.Map({
       container: 'map',
       style,
       center: [data.principal.lon, data.principal.lat],
       zoom: data.principal.zoom || 13,
-      maxZoom: typeof data.project?.maxZoom === 'number' ? data.project.maxZoom : 22
+      maxZoom: mapMaxZoom
     });
 
     map.addControl(new maplibregl.NavigationControl({ visualizePitch: true }));
@@ -327,12 +348,13 @@
     map.on('load', async () => {
       if (loadingEl) loadingEl.style.display = 'none';
 
-      const desiredMaxZoom = typeof data.principal?.maxZoom === 'number'
+      const desiredMaxZoom = Number.isFinite(data.principal?.maxZoom)
         ? data.principal.maxZoom
-        : map.getMaxZoom();
-      const clampedZoom = Math.min(desiredMaxZoom, map.getMaxZoom());
-      if (map.getZoom() < clampedZoom) {
-        map.setZoom(clampedZoom);
+        : mapMaxZoom;
+      const effectiveMaxZoom = Math.min(desiredMaxZoom, mapMaxZoom);
+      map.setMaxZoom(mapMaxZoom);
+      if (map.getZoom() > effectiveMaxZoom) {
+        map.setZoom(effectiveMaxZoom);
       }
 
       if (
@@ -377,7 +399,13 @@
             tileSize: 256,
             attribution: '© Stadia Maps'
           });
-          map.addLayer({ id: 'fallback-sat-layer', type: 'raster', source: 'fallback-satellite', minzoom: 0, maxzoom: 20 });
+          map.addLayer({
+            id: 'fallback-sat-layer',
+            type: 'raster',
+            source: 'fallback-satellite',
+            minzoom: 0,
+            maxzoom: mapMaxZoom
+          });
         }
       }
     });

--- a/map-platform-backend/src/templates/app.js
+++ b/map-platform-backend/src/templates/app.js
@@ -453,15 +453,37 @@
               }
             },
             layers: [
-              { id: 'satellite-layer', type: 'raster', source: 'satellite', minzoom: 0, maxzoom: 20 }
+              { id: 'satellite-layer', type: 'raster', source: 'satellite', minzoom: 0, maxzoom: 19 }
             ]
           };
+
+    const deriveStyleMaxZoom = (styleDefinition) => {
+      if (!styleDefinition || typeof styleDefinition === 'string') {
+        return undefined;
+      }
+      if (!Array.isArray(styleDefinition.layers)) {
+        return undefined;
+      }
+      const zoomLevels = styleDefinition.layers
+        .map((layer) => (typeof layer.maxzoom === 'number' ? layer.maxzoom : undefined))
+        .filter((value) => Number.isFinite(value));
+      if (!zoomLevels.length) {
+        return undefined;
+      }
+      return Math.max(...zoomLevels);
+    };
+
+    const DEFAULT_TILE_MAX_ZOOM = 19;
+    const styleMaxZoom = deriveStyleMaxZoom(style) ?? DEFAULT_TILE_MAX_ZOOM;
+    const projectMaxZoom = Number.isFinite(data.project?.maxZoom) ? data.project.maxZoom : styleMaxZoom;
+    const mapMaxZoom = Math.min(projectMaxZoom, styleMaxZoom);
 
     map = new maplibregl.Map({
       container: 'map',
       style,
       center: [data.principal.lon, data.principal.lat],
-      zoom: data.principal.zoom || 13
+      zoom: data.principal.zoom || 13,
+      maxZoom: mapMaxZoom
     });
 
     map.addControl(new maplibregl.NavigationControl({ visualizePitch: true }));
@@ -469,6 +491,15 @@
 
     map.on('load', async () => {
       if (loadingEl) loadingEl.style.display = 'none';
+
+      const desiredMaxZoom = Number.isFinite(data.principal?.maxZoom)
+        ? data.principal.maxZoom
+        : mapMaxZoom;
+      const effectiveMaxZoom = Math.min(desiredMaxZoom, mapMaxZoom);
+      map.setMaxZoom(mapMaxZoom);
+      if (map.getZoom() > effectiveMaxZoom) {
+        map.setZoom(effectiveMaxZoom);
+      }
 
       if (isFinite(data.principal.lon) && isFinite(data.principal.lat)) {
         let principalEl = null;
@@ -563,7 +594,13 @@
             tileSize: 256,
             attribution: '© Stadia Maps'
           });
-          map.addLayer({ id: 'fallback-sat-layer', type: 'raster', source: 'fallback-satellite', minzoom: 0, maxzoom: 20 });
+          map.addLayer({
+            id: 'fallback-sat-layer',
+            type: 'raster',
+            source: 'fallback-satellite',
+            minzoom: 0,
+            maxzoom: mapMaxZoom
+          });
         }
       }
     });


### PR DESCRIPTION
## Summary
- clamp the exported project map to the tile set's supported zoom range
- align fallback satellite layer limits with the computed safe maximum zoom
- mirror the safer zoom handling in the export template for future builds

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5623ff82c83249ba3237680c36a1a