### PR TITLE
Add reusable asset library and settings management

### DIFF
--- a/map-platform-backend/src/controllers/asset.controller.js
+++ b/map-platform-backend/src/controllers/asset.controller.js
@@ -1,0 +1,82 @@
+import { Asset } from '../models/Asset.js';
+
+export async function listAssets(req, res) {
+  const { type } = req.query;
+  const query = {};
+  if (type) {
+    query.type = type;
+  }
+
+  const docs = await Asset.find(query).sort({ label: 1 }).lean();
+  const items = docs.map((doc) => ({
+    ...doc,
+    _id: doc._id.toString(),
+    id: doc._id.toString(),
+  }));
+  res.json({ items });
+}
+
+export async function createAsset(req, res) {
+  const { type, label, url, publicId } = req.body;
+  try {
+    const item = await Asset.create({
+      type,
+      label: label.trim(),
+      url: url.trim(),
+      publicId: publicId?.trim() || undefined,
+    });
+    res.status(201).json({ item: item.toJSON() });
+  } catch (error) {
+    if (error.code === 11000) {
+      return res.status(409).json({ error: 'DuplicateAsset', message: 'An asset with the same label or URL already exists.' });
+    }
+    throw error;
+  }
+}
+
+export async function updateAsset(req, res) {
+  const { id } = req.params;
+  const { label, url, publicId } = req.body;
+
+  const patch = {};
+  if (typeof label === 'string') {
+    patch.label = label.trim();
+  }
+  if (typeof url === 'string') {
+    patch.url = url.trim();
+  }
+  if (typeof publicId === 'string') {
+    patch.publicId = publicId.trim();
+  }
+
+  if (!Object.keys(patch).length) {
+    return res.status(400).json({ error: 'NoUpdatesProvided', message: 'Provide at least one field to update.' });
+  }
+
+  try {
+    const doc = await Asset.findByIdAndUpdate(id, patch, {
+      new: true,
+      runValidators: true,
+    });
+
+    if (!doc) {
+      return res.status(404).json({ error: 'AssetNotFound', message: 'Asset not found.' });
+    }
+
+    res.json({ item: doc.toJSON() });
+  } catch (error) {
+    if (error.code === 11000) {
+      return res.status(409).json({ error: 'DuplicateAsset', message: 'An asset with the same label or URL already exists.' });
+    }
+    throw error;
+  }
+}
+
+export async function deleteAsset(req, res) {
+  const { id } = req.params;
+  const item = await Asset.findByIdAndDelete(id);
+  if (!item) {
+    return res.status(404).json({ error: 'AssetNotFound', message: 'Asset not found.' });
+  }
+  res.json({ ok: true });
+}

--- a/map-platform-backend/src/controllers/placeType.controller.js
+++ b/map-platform-backend/src/controllers/placeType.controller.js
@@ -1,0 +1,66 @@
+import { PlaceType } from '../models/PlaceType.js';
+
+export async function listPlaceTypes(_req, res) {
+  const docs = await PlaceType.find().sort({ name: 1 }).lean();
+  const items = docs.map((doc) => ({
+    ...doc,
+    _id: doc._id.toString(),
+    id: doc._id.toString(),
+  }));
+  res.json({ items });
+}
+
+export async function createPlaceType(req, res) {
+  const { name, description } = req.body;
+  try {
+    const item = await PlaceType.create({
+      name: name.trim(),
+      description: description?.trim() || undefined,
+    });
+    res.status(201).json({ item: item.toJSON() });
+  } catch (error) {
+    if (error.code === 11000) {
+      return res.status(409).json({ error: 'DuplicatePlaceType', message: 'A place type with this name already exists.' });
+    }
+    throw error;
+  }
+}
+
+export async function updatePlaceType(req, res) {
+  const { id } = req.params;
+  const { name, description } = req.body;
+
+  const patch = {};
+  if (typeof name === 'string') {
+    patch.name = name.trim();
+  }
+  if (typeof description === 'string') {
+    patch.description = description.trim();
+  }
+
+  if (!Object.keys(patch).length) {
+    return res.status(400).json({ error: 'NoUpdatesProvided', message: 'Provide at least one field to update.' });
+  }
+
+  try {
+    const doc = await PlaceType.findByIdAndUpdate(id, patch, { new: true, runValidators: true });
+    if (!doc) {
+      return res.status(404).json({ error: 'PlaceTypeNotFound', message: 'Place type not found.' });
+    }
+    res.json({ item: doc.toJSON() });
+  } catch (error) {
+    if (error.code === 11000) {
+      return res.status(409).json({ error: 'DuplicatePlaceType', message: 'A place type with this name already exists.' });
+    }
+    throw error;
+  }
+}
+
+export async function deletePlaceType(req, res) {
+  const { id } = req.params;
+  const doc = await PlaceType.findByIdAndDelete(id);
+  if (!doc) {
+    return res.status(404).json({ error: 'PlaceTypeNotFound', message: 'Place type not found.' });
+  }
+  res.json({ ok: true });
+}

--- a/map-platform-backend/src/index.js
+++ b/map-platform-backend/src/index.js
@@ -15,6 +15,8 @@ import projectRoutes from './routes/project.routes.js';
 import placeRoutes from './routes/place.routes.js';
 import uploadRoutes from './routes/upload.routes.js';
 import routeRoutes from './routes/route.routes.js';
+import assetRoutes from './routes/asset.routes.js';
+import placeTypeRoutes from './routes/placeType.routes.js';
 
 const app = express();
 
@@ -48,6 +50,8 @@ app.use('/api/projects', projectRoutes);
 app.use('/api/projects/:projectId/places', placeRoutes);
 app.use('/api/upload', uploadRoutes);
 app.use('/api/route', routeRoutes);
+app.use('/api/assets', assetRoutes);
+app.use('/api/place-types', placeTypeRoutes);
 
 
 

--- a/map-platform-backend/src/models/Asset.js
+++ b/map-platform-backend/src/models/Asset.js
@@ -1,0 +1,43 @@
+import mongoose from 'mongoose';
+
+const assetSchema = new mongoose.Schema(
+  {
+    type: {
+      type: String,
+      enum: ['logo', 'panorama'],
+      required: true,
+      index: true,
+    },
+    label: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    url: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+    publicId: {
+      type: String,
+      trim: true,
+    },
+  },
+  {
+    timestamps: true,
+    toJSON: {
+      virtuals: true,
+      versionKey: false,
+      transform: (_doc, ret) => {
+        ret.id = ret._id.toString();
+        delete ret._id;
+        return ret;
+      },
+    },
+  },
+);
+
+assetSchema.index({ type: 1, label: 1 }, { unique: true });
+assetSchema.index({ type: 1, url: 1 }, { unique: true });
+
+export const Asset = mongoose.model('Asset', assetSchema);

--- a/map-platform-backend/src/models/PlaceType.js
+++ b/map-platform-backend/src/models/PlaceType.js
@@ -1,0 +1,30 @@
+import mongoose from 'mongoose';
+
+const placeTypeSchema = new mongoose.Schema(
+  {
+    name: {
+      type: String,
+      required: true,
+      trim: true,
+      unique: true,
+    },
+    description: {
+      type: String,
+      trim: true,
+    },
+  },
+  {
+    timestamps: true,
+    toJSON: {
+      virtuals: true,
+      versionKey: false,
+      transform: (_doc, ret) => {
+        ret.id = ret._id.toString();
+        delete ret._id;
+        return ret;
+      },
+    },
+  },
+);
+
+export const PlaceType = mongoose.model('PlaceType', placeTypeSchema);

--- a/map-platform-backend/src/routes/asset.routes.js
+++ b/map-platform-backend/src/routes/asset.routes.js
@@ -1,0 +1,14 @@
+import { Router } from 'express';
+import { asyncHandler } from '../middlewares/asyncHandler.js';
+import { validate } from '../middlewares/validate.js';
+import { createAsset, deleteAsset, listAssets, updateAsset } from '../controllers/asset.controller.js';
+import { createAssetZ, listAssetsQueryZ, updateAssetZ } from '../schemas/asset.schema.js';
+
+const router = Router();
+
+router.get('/', validate(listAssetsQueryZ, 'query'), asyncHandler(listAssets));
+router.post('/', validate(createAssetZ), asyncHandler(createAsset));
+router.put('/:id', validate(updateAssetZ), asyncHandler(updateAsset));
+router.delete('/:id', asyncHandler(deleteAsset));
+
+export default router;

--- a/map-platform-backend/src/routes/placeType.routes.js
+++ b/map-platform-backend/src/routes/placeType.routes.js
@@ -1,0 +1,19 @@
+import { Router } from 'express';
+import { asyncHandler } from '../middlewares/asyncHandler.js';
+import { validate } from '../middlewares/validate.js';
+import {
+  createPlaceType,
+  deletePlaceType,
+  listPlaceTypes,
+  updatePlaceType,
+} from '../controllers/placeType.controller.js';
+import { createPlaceTypeZ, updatePlaceTypeZ } from '../schemas/placeType.schema.js';
+
+const router = Router();
+
+router.get('/', asyncHandler(listPlaceTypes));
+router.post('/', validate(createPlaceTypeZ), asyncHandler(createPlaceType));
+router.put('/:id', validate(updatePlaceTypeZ), asyncHandler(updatePlaceType));
+router.delete('/:id', asyncHandler(deletePlaceType));
+
+export default router;

--- a/map-platform-backend/src/schemas/asset.schema.js
+++ b/map-platform-backend/src/schemas/asset.schema.js
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+const assetTypeEnum = z.enum(['logo', 'panorama']);
+
+export const listAssetsQueryZ = z.object({
+  type: assetTypeEnum.optional(),
+});
+
+export const createAssetZ = z.object({
+  type: assetTypeEnum,
+  label: z.string().min(1, 'Label is required').trim(),
+  url: z.string().url('A valid asset URL is required').trim(),
+  publicId: z.string().min(1).optional(),
+});
+
+export const updateAssetZ = z
+  .object({
+    label: z.string().min(1).trim().optional(),
+    url: z.string().url().trim().optional(),
+    publicId: z.string().min(1).optional(),
+  })
+  .refine((data) => Object.keys(data).length > 0, {
+    message: 'At least one field must be provided',
+    path: ['label'],
+  });

--- a/map-platform-backend/src/schemas/placeType.schema.js
+++ b/map-platform-backend/src/schemas/placeType.schema.js
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+export const createPlaceTypeZ = z.object({
+  name: z.string().min(1, 'Name is required').trim(),
+  description: z.string().trim().optional(),
+});
+
+export const updatePlaceTypeZ = z
+  .object({
+    name: z.string().min(1).trim().optional(),
+    description: z.string().trim().optional(),
+  })
+  .refine((data) => Object.keys(data).length > 0, {
+    message: 'At least one field must be provided',
+    path: ['name'],
+  });

--- a/map-platform-frontend/app/page.tsx
+++ b/map-platform-frontend/app/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { motion } from 'framer-motion'
 import { Download, Loader2, Save } from 'lucide-react'
 import { ProjectHero } from '@/components/project/ProjectHero'
@@ -11,6 +11,7 @@ import { ExportProjectDialog } from '@/components/project/ExportProjectDialog'
 import { useStudio } from '@/lib/studioStore'
 import { saveProject } from '@/lib/api'
 import type { ExportOptions } from '@/types'
+import { useAssetLibrary } from '@/lib/assetLibraryStore'
 
 const DEFAULT_EXPORT: ExportOptions = {
   includeSecondaries: true,
@@ -25,12 +26,21 @@ export default function StudioPage() {
     backend: state.backend,
   }))
 
+  const fetchLibrary = useAssetLibrary((state) => state.fetchAll)
+  const libraryLoaded = useAssetLibrary((state) => state.initialized)
+
   const [saving, setSaving] = useState(false)
   const [exporting, setExporting] = useState(false)
   const [exportOpen, setExportOpen] = useState(false)
   const [options, setOptions] = useState<ExportOptions>(DEFAULT_EXPORT)
 
   const allPlaces = useMemo(() => [project.principal, ...project.secondaries], [project])
+
+  useEffect(() => {
+    if (!libraryLoaded) {
+      fetchLibrary(backend)
+    }
+  }, [backend, fetchLibrary, libraryLoaded])
 
   const ensureMediaIsValid = useCallback(() => {
     for (const place of allPlaces) {

--- a/map-platform-frontend/app/settings/page.tsx
+++ b/map-platform-frontend/app/settings/page.tsx
@@ -1,0 +1,387 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import Link from 'next/link'
+import { Loader2, Pencil, PlusCircle, Trash2, UploadCloud } from 'lucide-react'
+import { useStudio } from '@/lib/studioStore'
+import { useAssetLibrary } from '@/lib/assetLibraryStore'
+import { uploadImage } from '@/lib/api'
+import type { AssetKind, LibraryAsset, PlaceTypeDefinition } from '@/types'
+
+function useLibraryBootstrap(backend: string) {
+  const fetchLibrary = useAssetLibrary((state) => state.fetchAll)
+  const initialized = useAssetLibrary((state) => state.initialized)
+
+  useEffect(() => {
+    if (!initialized) {
+      fetchLibrary(backend)
+    }
+  }, [backend, fetchLibrary, initialized])
+}
+
+interface AssetManagerSectionProps {
+  title: string
+  description: string
+  type: AssetKind
+  backend: string
+}
+
+function AssetManagerSection({ title, description, type, backend }: AssetManagerSectionProps) {
+  const assets = useAssetLibrary((state) => (type === 'logo' ? state.logos : state.panoramas))
+  const createAsset = useAssetLibrary((state) => state.createAsset)
+  const updateAsset = useAssetLibrary((state) => state.updateAsset)
+  const deleteAsset = useAssetLibrary((state) => state.deleteAsset)
+
+  const [label, setLabel] = useState('')
+  const [file, setFile] = useState<File | null>(null)
+  const [uploading, setUploading] = useState(false)
+
+  const readyToUpload = useMemo(() => Boolean(label.trim() && file), [label, file])
+
+  const handleUpload = useCallback(async () => {
+    if (!file) {
+      alert('Select a file to upload.')
+      return
+    }
+    const trimmedLabel = label.trim()
+    if (!trimmedLabel) {
+      alert('Provide a label for this asset.')
+      return
+    }
+    setUploading(true)
+    try {
+      const response = await uploadImage(file, backend)
+      await createAsset(backend, {
+        type,
+        label: trimmedLabel,
+        url: response.url,
+        publicId: response.public_id,
+      })
+      setLabel('')
+      setFile(null)
+    } catch (error) {
+      console.error('Unable to create asset', error)
+      alert('Upload failed. Please try again or check your backend configuration.')
+    } finally {
+      setUploading(false)
+    }
+  }, [backend, createAsset, file, label, type])
+
+  const handleRename = useCallback(
+    async (asset: LibraryAsset) => {
+      const next = window.prompt('Rename asset', asset.label)
+      if (!next) return
+      const trimmed = next.trim()
+      if (!trimmed || trimmed === asset.label) return
+      try {
+        await updateAsset(backend, asset._id, { label: trimmed })
+      } catch (error) {
+        console.error('Rename failed', error)
+        alert('Unable to rename asset. Please try again.')
+      }
+    },
+    [backend, updateAsset],
+  )
+
+  const handleDelete = useCallback(
+    async (asset: LibraryAsset) => {
+      if (!window.confirm(`Delete asset "${asset.label}"?`)) return
+      try {
+        await deleteAsset(backend, asset._id, type)
+      } catch (error) {
+        console.error('Delete failed', error)
+        alert('Unable to delete asset. Please try again.')
+      }
+    },
+    [backend, deleteAsset, type],
+  )
+
+  return (
+    <section className="space-y-4 rounded-3xl border border-navy-100 bg-white/80 p-6 shadow-lg">
+      <header className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-navy-900">{title}</h2>
+          <p className="text-sm text-navy-600">{description}</p>
+        </div>
+      </header>
+
+      <div className="rounded-2xl border border-dashed border-navy-200 bg-navy-50/40 p-4">
+        <div className="grid gap-3 md:grid-cols-[2fr_1fr_auto] md:items-end">
+          <label className="text-xs font-medium text-navy-700">
+            Asset label
+            <input
+              value={label}
+              onChange={(event) => setLabel(event.target.value)}
+              placeholder="e.g. Skyline at dusk"
+              className="mt-1 w-full rounded-xl border border-navy-200 px-3 py-2 text-sm focus:border-gold-400 focus:outline-none"
+            />
+          </label>
+          <label className="text-xs font-medium text-navy-700">
+            Upload file
+            <input
+              type="file"
+              accept="image/*"
+              onChange={(event) => setFile(event.target.files?.[0] ?? null)}
+              className="mt-1 w-full rounded-xl border border-navy-200 px-3 py-2 text-sm focus:border-gold-400 focus:outline-none"
+            />
+          </label>
+          <button
+            type="button"
+            onClick={handleUpload}
+            disabled={!readyToUpload || uploading}
+            className="inline-flex items-center justify-center gap-2 rounded-full bg-navy-900 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-navy-700 disabled:cursor-not-allowed disabled:bg-navy-400"
+          >
+            {uploading ? <Loader2 className="h-4 w-4 animate-spin" /> : <UploadCloud className="h-4 w-4" />} Upload
+          </button>
+        </div>
+        <p className="mt-2 text-xs text-navy-500">
+          Uploaded assets are saved to Cloudinary and shared across your projects.
+        </p>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {assets.map((asset) => (
+          <article
+            key={asset._id}
+            className="flex h-full flex-col overflow-hidden rounded-2xl border border-navy-100 bg-white shadow"
+          >
+            <img src={asset.url} alt={asset.label} className="h-40 w-full object-cover" />
+            <div className="flex flex-1 flex-col justify-between gap-3 p-4">
+              <div>
+                <h3 className="text-sm font-semibold text-navy-900">{asset.label}</h3>
+                <p className="text-xs text-navy-500 break-all">{asset.url}</p>
+              </div>
+              <div className="flex items-center gap-2 text-xs font-semibold">
+                <button
+                  type="button"
+                  onClick={() => handleRename(asset)}
+                  className="inline-flex items-center gap-1 rounded-full border border-navy-200 px-3 py-1 text-navy-700 transition hover:border-gold-400 hover:text-gold-600"
+                >
+                  <Pencil className="h-4 w-4" /> Rename
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleDelete(asset)}
+                  className="inline-flex items-center gap-1 rounded-full bg-rose-50 px-3 py-1 text-rose-600 transition hover:bg-rose-100"
+                >
+                  <Trash2 className="h-4 w-4" /> Delete
+                </button>
+              </div>
+            </div>
+          </article>
+        ))}
+        {assets.length === 0 ? (
+          <div className="rounded-2xl border border-dashed border-navy-200 bg-navy-50/60 p-6 text-sm text-navy-600">
+            No assets yet. Upload your first one to populate the library.
+          </div>
+        ) : null}
+      </div>
+    </section>
+  )
+}
+
+interface PlaceTypeManagerSectionProps {
+  backend: string
+}
+
+function PlaceTypeManagerSection({ backend }: PlaceTypeManagerSectionProps) {
+  const placeTypes = useAssetLibrary((state) => state.placeTypes)
+  const createPlaceType = useAssetLibrary((state) => state.createPlaceType)
+  const updatePlaceType = useAssetLibrary((state) => state.updatePlaceType)
+  const deletePlaceType = useAssetLibrary((state) => state.deletePlaceType)
+
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [saving, setSaving] = useState(false)
+
+  const handleCreate = useCallback(async () => {
+    const trimmed = name.trim()
+    if (!trimmed) {
+      alert('Provide a name for the place type.')
+      return
+    }
+    setSaving(true)
+    try {
+      await createPlaceType(backend, { name: trimmed, description: description.trim() || undefined })
+      setName('')
+      setDescription('')
+    } catch (error) {
+      console.error('Unable to create place type', error)
+      alert('Creation failed. Please try again.')
+    } finally {
+      setSaving(false)
+    }
+  }, [backend, createPlaceType, description, name])
+
+  const handleRename = useCallback(
+    async (type: PlaceTypeDefinition) => {
+      const next = window.prompt('Rename place type', type.name)
+      if (!next) return
+      const trimmed = next.trim()
+      if (!trimmed || trimmed === type.name) return
+      try {
+        await updatePlaceType(backend, type._id, { name: trimmed })
+      } catch (error) {
+        console.error('Rename failed', error)
+        alert('Unable to rename place type. Please try again.')
+      }
+    },
+    [backend, updatePlaceType],
+  )
+
+  const handleDescriptionEdit = useCallback(
+    async (type: PlaceTypeDefinition) => {
+      const next = window.prompt('Update description', type.description ?? '')
+      if (next === null) return
+      const trimmed = next.trim()
+      try {
+        await updatePlaceType(backend, type._id, { description: trimmed || undefined })
+      } catch (error) {
+        console.error('Update failed', error)
+        alert('Unable to update description. Please try again.')
+      }
+    },
+    [backend, updatePlaceType],
+  )
+
+  const handleDelete = useCallback(
+    async (type: PlaceTypeDefinition) => {
+      if (!window.confirm(`Delete place type "${type.name}"?`)) return
+      try {
+        await deletePlaceType(backend, type._id)
+      } catch (error) {
+        console.error('Delete failed', error)
+        alert('Unable to delete place type. Please try again.')
+      }
+    },
+    [backend, deletePlaceType],
+  )
+
+  return (
+    <section className="space-y-4 rounded-3xl border border-navy-100 bg-white/80 p-6 shadow-lg">
+      <header className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-navy-900">Place types</h2>
+          <p className="text-sm text-navy-600">Define reusable categories for your places.</p>
+        </div>
+      </header>
+
+      <div className="rounded-2xl border border-dashed border-navy-200 bg-navy-50/40 p-4">
+        <div className="grid gap-3 md:grid-cols-[2fr_2fr_auto] md:items-end">
+          <label className="text-xs font-medium text-navy-700">
+            Name
+            <input
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              placeholder="e.g. Boutique hotel"
+              className="mt-1 w-full rounded-xl border border-navy-200 px-3 py-2 text-sm focus:border-gold-400 focus:outline-none"
+            />
+          </label>
+          <label className="text-xs font-medium text-navy-700">
+            Description (optional)
+            <input
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              placeholder="Short description"
+              className="mt-1 w-full rounded-xl border border-navy-200 px-3 py-2 text-sm focus:border-gold-400 focus:outline-none"
+            />
+          </label>
+          <button
+            type="button"
+            onClick={handleCreate}
+            disabled={saving}
+            className="inline-flex items-center justify-center gap-2 rounded-full bg-navy-900 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-navy-700 disabled:cursor-not-allowed disabled:bg-navy-400"
+          >
+            {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <PlusCircle className="h-4 w-4" />} Add type
+          </button>
+        </div>
+        <p className="mt-2 text-xs text-navy-500">Place types appear in the dropdowns on your project forms.</p>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-2">
+        {placeTypes.map((type) => (
+          <article key={type._id} className="flex flex-col justify-between rounded-2xl border border-navy-100 bg-white p-4 shadow">
+            <div>
+              <h3 className="text-sm font-semibold text-navy-900">{type.name}</h3>
+              {type.description ? (
+                <p className="mt-1 text-xs text-navy-600">{type.description}</p>
+              ) : (
+                <p className="mt-1 text-xs text-navy-500 italic">No description</p>
+              )}
+            </div>
+            <div className="mt-3 flex flex-wrap items-center gap-2 text-xs font-semibold">
+              <button
+                type="button"
+                onClick={() => handleRename(type)}
+                className="inline-flex items-center gap-1 rounded-full border border-navy-200 px-3 py-1 text-navy-700 transition hover:border-gold-400 hover:text-gold-600"
+              >
+                <Pencil className="h-4 w-4" /> Rename
+              </button>
+              <button
+                type="button"
+                onClick={() => handleDescriptionEdit(type)}
+                className="inline-flex items-center gap-1 rounded-full border border-navy-200 px-3 py-1 text-navy-700 transition hover:border-gold-400 hover:text-gold-600"
+              >
+                <Pencil className="h-4 w-4" /> Edit description
+              </button>
+              <button
+                type="button"
+                onClick={() => handleDelete(type)}
+                className="inline-flex items-center gap-1 rounded-full bg-rose-50 px-3 py-1 text-rose-600 transition hover:bg-rose-100"
+              >
+                <Trash2 className="h-4 w-4" /> Delete
+              </button>
+            </div>
+          </article>
+        ))}
+        {placeTypes.length === 0 ? (
+          <div className="rounded-2xl border border-dashed border-navy-200 bg-navy-50/60 p-6 text-sm text-navy-600">
+            No place types yet. Create your first entry above.
+          </div>
+        ) : null}
+      </div>
+    </section>
+  )
+}
+
+export default function SettingsPage() {
+  const backend = useStudio((state) => state.backend)
+  useLibraryBootstrap(backend)
+
+  return (
+    <main className="min-h-screen bg-navy-50/40 pb-16">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-6 py-10">
+        <header className="flex flex-col gap-3 rounded-3xl border border-navy-100 bg-white/90 p-6 shadow-xl">
+          <div>
+            <h1 className="text-2xl font-semibold text-navy-900">Asset Library Settings</h1>
+            <p className="text-sm text-navy-600">Manage reusable logos, 360° panoramas, and place types for your projects.</p>
+          </div>
+          <div className="flex flex-wrap items-center gap-3 text-sm">
+            <Link
+              href="/"
+              className="inline-flex items-center gap-2 rounded-full border border-navy-200 px-4 py-2 font-semibold text-navy-800 transition hover:border-gold-400 hover:text-gold-600"
+            >
+              Return to studio
+            </Link>
+          </div>
+        </header>
+
+        <AssetManagerSection
+          title="Place logos"
+          description="Store organization and project logos for reuse across multiple places."
+          type="logo"
+          backend={backend}
+        />
+
+        <AssetManagerSection
+          title="360° panoramas"
+          description="Upload immersive panoramas once and reuse them across different locations."
+          type="panorama"
+          backend={backend}
+        />
+
+        <PlaceTypeManagerSection backend={backend} />
+      </div>
+    </main>
+  )
+}

--- a/map-platform-frontend/components/library/AssetSelectorField.tsx
+++ b/map-platform-frontend/components/library/AssetSelectorField.tsx
@@ -1,0 +1,192 @@
+'use client'
+
+import Link from 'next/link'
+import { useCallback, useMemo, useRef, useState } from 'react'
+import { ImageIcon, Loader2, PlusCircle, XCircle } from 'lucide-react'
+import { uploadImage } from '@/lib/api'
+import { useAssetLibrary } from '@/lib/assetLibraryStore'
+import type { AssetKind, LibraryAsset } from '@/types'
+
+interface AssetSelectorFieldProps {
+  label: string
+  description?: string
+  type: AssetKind
+  value?: string
+  backend: string
+  onChange: (asset: LibraryAsset | null) => void
+}
+
+export function AssetSelectorField({ label, description, type, value, backend, onChange }: AssetSelectorFieldProps) {
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
+  const [showUploader, setShowUploader] = useState(false)
+  const [newLabel, setNewLabel] = useState('')
+  const [selectedFile, setSelectedFile] = useState<File | null>(null)
+  const [uploading, setUploading] = useState(false)
+
+  const assets = useAssetLibrary((state) => (type === 'logo' ? state.logos : state.panoramas))
+  const createAsset = useAssetLibrary((state) => state.createAsset)
+
+  const selectedAsset = useMemo(() => {
+    if (!value) return undefined
+    return assets.find((asset) => asset.url === value)
+  }, [assets, value])
+
+  const handleSelectChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>) => {
+      const id = event.target.value
+      if (!id) {
+        onChange(null)
+        return
+      }
+      const asset = assets.find((item) => item._id === id)
+      if (asset) {
+        onChange(asset)
+      }
+    },
+    [assets, onChange],
+  )
+
+  const handleFileChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    setSelectedFile(file ?? null)
+  }, [])
+
+  const resetUploader = useCallback(() => {
+    setShowUploader(false)
+    setNewLabel('')
+    setSelectedFile(null)
+    if (fileInputRef.current) {
+      fileInputRef.current.value = ''
+    }
+  }, [])
+
+  const handleUpload = useCallback(async () => {
+    if (!selectedFile) {
+      alert('Select an image to upload.')
+      return
+    }
+    const trimmedLabel = newLabel.trim()
+    if (!trimmedLabel) {
+      alert('Provide a label for this asset before uploading.')
+      return
+    }
+    setUploading(true)
+    try {
+      const response = await uploadImage(selectedFile, backend)
+      const asset = await createAsset(backend, {
+        type,
+        label: trimmedLabel,
+        url: response.url,
+        publicId: response.public_id,
+      })
+      onChange(asset)
+      resetUploader()
+    } catch (error) {
+      console.error('Asset upload failed', error)
+      alert('Unable to upload the asset. Please try again.')
+    } finally {
+      setUploading(false)
+    }
+  }, [backend, createAsset, newLabel, onChange, resetUploader, selectedFile, type])
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <p className="text-sm font-semibold text-navy-900">{label}</p>
+          {description ? <p className="text-xs text-navy-600">{description}</p> : null}
+          {selectedAsset ? (
+            <p className="mt-1 text-xs font-medium text-gold-700">Selected: {selectedAsset.label}</p>
+          ) : value ? (
+            <p className="mt-1 text-xs font-medium text-navy-600">Using custom URL</p>
+          ) : (
+            <p className="mt-1 text-xs text-navy-500">No asset selected</p>
+          )}
+        </div>
+        {value ? (
+          <button
+            type="button"
+            onClick={() => onChange(null)}
+            className="inline-flex items-center gap-1 rounded-full bg-navy-50 px-2 py-1 text-xs font-semibold text-navy-600 transition hover:bg-navy-100"
+          >
+            <XCircle className="h-4 w-4" /> Clear
+          </button>
+        ) : null}
+      </div>
+
+      <select
+        value={selectedAsset?._id ?? ''}
+        onChange={handleSelectChange}
+        className="w-full rounded-xl border border-navy-200 px-3 py-2 text-sm text-navy-900 shadow-inner focus:border-gold-400 focus:outline-none"
+      >
+        <option value="">Select from library…</option>
+        {assets.map((asset) => (
+          <option key={asset._id} value={asset._id}>
+            {asset.label}
+          </option>
+        ))}
+      </select>
+
+      <div className="flex flex-wrap items-center gap-3 text-xs">
+        <button
+          type="button"
+          onClick={() => setShowUploader((prev) => !prev)}
+          className="inline-flex items-center gap-2 rounded-full border border-dashed border-navy-300 px-3 py-1.5 font-semibold text-navy-700 transition hover:border-gold-400 hover:text-gold-600"
+        >
+          <PlusCircle className="h-4 w-4" /> {showUploader ? 'Close uploader' : 'Add new asset'}
+        </button>
+        <Link href="/settings" className="inline-flex items-center gap-1 text-navy-600 hover:text-gold-600">
+          Manage library
+        </Link>
+      </div>
+
+      {showUploader ? (
+        <div className="space-y-3 rounded-2xl border border-navy-200 bg-white/70 p-4 shadow-inner">
+          <label className="flex flex-col gap-1 text-xs font-medium text-navy-700">
+            Asset label
+            <input
+              value={newLabel}
+              onChange={(event) => setNewLabel(event.target.value)}
+              placeholder="e.g. Sunset exterior"
+              className="rounded-xl border border-navy-200 px-3 py-2 text-sm focus:border-gold-400 focus:outline-none"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-xs font-medium text-navy-700">
+            Upload image
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              onChange={handleFileChange}
+              className="rounded-xl border border-navy-200 px-3 py-2 text-sm focus:border-gold-400 focus:outline-none"
+            />
+          </label>
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              onClick={handleUpload}
+              disabled={uploading}
+              className="inline-flex items-center gap-2 rounded-full bg-navy-900 px-4 py-1.5 text-sm font-semibold text-white shadow transition hover:bg-navy-700 disabled:cursor-not-allowed disabled:bg-navy-400"
+            >
+              {uploading ? <Loader2 className="h-4 w-4 animate-spin" /> : <ImageIcon className="h-4 w-4" />} Upload to library
+            </button>
+            <button
+              type="button"
+              onClick={resetUploader}
+              className="text-xs font-semibold text-rose-600 hover:text-rose-500"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      {selectedAsset ? (
+        <figure className="overflow-hidden rounded-2xl border border-navy-100 bg-white shadow">
+          <img src={selectedAsset.url} alt={selectedAsset.label} className="h-48 w-full object-cover" />
+          <figcaption className="px-3 py-2 text-xs font-medium text-navy-700">{selectedAsset.label}</figcaption>
+        </figure>
+      ) : null}
+    </div>
+  )
+}

--- a/map-platform-frontend/components/library/PlaceTypeSelectField.tsx
+++ b/map-platform-frontend/components/library/PlaceTypeSelectField.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import Link from 'next/link'
+import { useMemo } from 'react'
+import { useAssetLibrary } from '@/lib/assetLibraryStore'
+
+interface PlaceTypeSelectFieldProps {
+  label: string
+  value?: string
+  onChange: (value?: string) => void
+  description?: string
+}
+
+export function PlaceTypeSelectField({ label, value, onChange, description }: PlaceTypeSelectFieldProps) {
+  const placeTypes = useAssetLibrary((state) => state.placeTypes)
+
+  const options = useMemo(
+    () => placeTypes.map((item) => ({ key: item._id, value: item.name, label: item.name })),
+    [placeTypes],
+  )
+
+  return (
+    <div className="space-y-2 text-sm">
+      <div className="flex items-center justify-between gap-2">
+        <div>
+          <span className="font-medium text-navy-800">{label}</span>
+          {description ? <p className="text-xs text-navy-600">{description}</p> : null}
+        </div>
+        <Link href="/settings" className="text-xs font-semibold text-navy-600 hover:text-gold-600">
+          Manage types
+        </Link>
+      </div>
+      <select
+        value={value ?? ''}
+        onChange={(event) => onChange(event.target.value || undefined)}
+        className="w-full rounded-xl border border-navy-100 px-3 py-2 text-sm focus:border-gold-400 focus:outline-none"
+      >
+        <option value="">Select place type…</option>
+        {options.map((option) => (
+          <option key={option.key} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+      {options.length === 0 ? (
+        <p className="text-xs text-rose-600">No place types yet. Add them from settings.</p>
+      ) : null}
+    </div>
+  )
+}

--- a/map-platform-frontend/components/project/PrincipalPlaceForm.tsx
+++ b/map-platform-frontend/components/project/PrincipalPlaceForm.tsx
@@ -3,8 +3,10 @@
 import { useCallback, useMemo } from 'react'
 import { motion } from 'framer-motion'
 import { useStudio } from '@/lib/studioStore'
-import { prettyLatLng, uploadImage } from '@/lib/api'
-import { UploadField } from './UploadField'
+import { prettyLatLng } from '@/lib/api'
+import type { LibraryAsset } from '@/types'
+import { AssetSelectorField } from '@/components/library/AssetSelectorField'
+import { PlaceTypeSelectField } from '@/components/library/PlaceTypeSelectField'
 import { MediaPreview } from './MediaPreview'
 
 export function PrincipalPlaceForm() {
@@ -21,20 +23,22 @@ export function PrincipalPlaceForm() {
     [principal.latitude, principal.longitude],
   )
 
-  const handleHeroUpload = useCallback(
-    async (file: File) => {
-      const response = await uploadImage(file, backend)
-      updatePrincipal({ virtualtour: response.url, tourUrl: undefined })
+  const handleHeroAsset = useCallback(
+    (asset: LibraryAsset | null) => {
+      if (asset) {
+        updatePrincipal({ virtualtour: asset.url, tourUrl: undefined })
+      } else {
+        updatePrincipal({ virtualtour: undefined })
+      }
     },
-    [backend, updatePrincipal],
+    [updatePrincipal],
   )
 
-  const handleLogoUpload = useCallback(
-    async (file: File) => {
-      const response = await uploadImage(file, backend)
-      updatePrincipal({ logoUrl: response.url })
+  const handleLogoAsset = useCallback(
+    (asset: LibraryAsset | null) => {
+      updatePrincipal({ logoUrl: asset?.url })
     },
-    [backend, updatePrincipal],
+    [updatePrincipal],
   )
 
   return (
@@ -84,14 +88,11 @@ export function PrincipalPlaceForm() {
             />
           </div>
         </div>
-        <label className="space-y-2 text-sm">
-          <span className="font-medium text-navy-800">Place type</span>
-          <input
-            value={principal.placeType ?? ''}
-            onChange={(event) => updatePrincipal({ placeType: event.target.value })}
-            className="w-full rounded-2xl border border-navy-100 px-4 py-2 text-sm focus:border-gold-400 focus:outline-none"
-          />
-        </label>
+        <PlaceTypeSelectField
+          label="Place type"
+          value={principal.placeType}
+          onChange={(next) => updatePrincipal({ placeType: next })}
+        />
         <label className="space-y-2 text-sm">
           <span className="font-medium text-navy-800">Google Maps link</span>
           <input
@@ -138,24 +139,21 @@ export function PrincipalPlaceForm() {
       </div>
 
       <div className="mt-6 grid gap-6 lg:grid-cols-2">
-        <UploadField
+        <AssetSelectorField
           label="Hero panorama or 360° image"
-          description="Upload an equirectangular image"
-          previewUrl={principal.virtualtour}
-          onUpload={handleHeroUpload}
-          onRemove={() => updatePrincipal({ virtualtour: undefined })}
-          cta="Upload hero media"
-          accept={{ 'image/*': [] }}
+          description="Choose a panorama from your library"
+          type="panorama"
+          value={principal.virtualtour}
+          backend={backend}
+          onChange={handleHeroAsset}
         />
-        <UploadField
+        <AssetSelectorField
           label="Principal logo"
           description="This replaces legacy 3D models"
-          previewUrl={principal.logoUrl}
-          onUpload={handleLogoUpload}
-          onRemove={() => updatePrincipal({ logoUrl: undefined })}
-          cta="Upload logo"
-          accept={{ 'image/*': [] }}
-          borderlessPreview
+          type="logo"
+          value={principal.logoUrl}
+          backend={backend}
+          onChange={handleLogoAsset}
         />
       </div>
 

--- a/map-platform-frontend/components/project/ProjectHero.tsx
+++ b/map-platform-frontend/components/project/ProjectHero.tsx
@@ -3,8 +3,8 @@
 import { useCallback } from 'react'
 import { motion } from 'framer-motion'
 import { useStudio } from '@/lib/studioStore'
-import { uploadImage } from '@/lib/api'
-import { UploadField } from './UploadField'
+import type { LibraryAsset } from '@/types'
+import { AssetSelectorField } from '@/components/library/AssetSelectorField'
 
 export function ProjectHero() {
   const { project, updateProject, backend, setBackend } = useStudio((state) => ({
@@ -14,12 +14,11 @@ export function ProjectHero() {
     setBackend: state.setBackend,
   }))
 
-  const handleLogoUpload = useCallback(
-    async (file: File) => {
-      const response = await uploadImage(file, backend)
-      updateProject({ logoUrl: response.url })
+  const handleLogoChange = useCallback(
+    (asset: LibraryAsset | null) => {
+      updateProject({ logoUrl: asset?.url })
     },
-    [backend, updateProject],
+    [updateProject],
   )
 
   return (
@@ -50,14 +49,13 @@ export function ProjectHero() {
           {/* Advanced inputs removed per request */}
         </div>
         <div className="w-full max-w-xs">
-          <UploadField
+          <AssetSelectorField
             label="Project branding"
-            description="Recommended: transparent PNG or SVG"
-            previewUrl={project.logoUrl}
-            onUpload={handleLogoUpload}
-            onRemove={() => updateProject({ logoUrl: undefined })}
-            cta="Upload logo"
-            accept={{ 'image/*': [] }}
+            description="Logos are shared across your library"
+            type="logo"
+            value={project.logoUrl}
+            backend={backend}
+            onChange={handleLogoChange}
           />
         </div>
       </div>

--- a/map-platform-frontend/components/project/SecondaryPlaceCard.tsx
+++ b/map-platform-frontend/components/project/SecondaryPlaceCard.tsx
@@ -3,10 +3,11 @@
 import { useCallback, useMemo, useState } from 'react'
 import { motion } from 'framer-motion'
 import { MapPin, Route as RouteIcon, Trash2 } from 'lucide-react'
-import { computeRoute, prettyLatLng, uploadImage } from '@/lib/api'
+import { computeRoute, prettyLatLng } from '@/lib/api'
 import { useStudio } from '@/lib/studioStore'
-import type { Place } from '@/types'
-import { UploadField } from './UploadField'
+import type { LibraryAsset, Place } from '@/types'
+import { AssetSelectorField } from '@/components/library/AssetSelectorField'
+import { PlaceTypeSelectField } from '@/components/library/PlaceTypeSelectField'
 import { MediaPreview } from './MediaPreview'
 
 interface SecondaryPlaceCardProps {
@@ -35,20 +36,22 @@ export function SecondaryPlaceCard({ place }: SecondaryPlaceCardProps) {
     [placeId, replaceSecondary],
   )
 
-  const handleHeroUpload = useCallback(
-    async (file: File) => {
-      const response = await uploadImage(file, backend)
-      update({ virtualtour: response.url, tourUrl: undefined })
+  const handleHeroAsset = useCallback(
+    (asset: LibraryAsset | null) => {
+      if (asset) {
+        update({ virtualtour: asset.url, tourUrl: undefined })
+      } else {
+        update({ virtualtour: undefined })
+      }
     },
-    [backend, update],
+    [update],
   )
 
-  const handleLogoUpload = useCallback(
-    async (file: File) => {
-      const response = await uploadImage(file, backend)
-      update({ logoUrl: response.url })
+  const handleLogoAsset = useCallback(
+    (asset: LibraryAsset | null) => {
+      update({ logoUrl: asset?.url })
     },
-    [backend, update],
+    [update],
   )
 
   const handleRoute = useCallback(async () => {
@@ -121,14 +124,11 @@ export function SecondaryPlaceCard({ place }: SecondaryPlaceCardProps) {
       </div>
 
       <div className="mt-4 grid gap-3 md:grid-cols-2">
-        <label className="space-y-1 text-xs font-medium text-navy-700">
-          Place type
-          <input
-            value={place.placeType ?? ''}
-            onChange={(event) => update({ placeType: event.target.value })}
-            className="w-full rounded-xl border border-navy-100 px-3 py-2 text-sm focus:border-gold-400 focus:outline-none"
-          />
-        </label>
+        <PlaceTypeSelectField
+          label="Place type"
+          value={place.placeType}
+          onChange={(next) => update({ placeType: next })}
+        />
         <label className="space-y-1 text-xs font-medium text-navy-700">
           Google Maps link
           <input
@@ -193,24 +193,21 @@ export function SecondaryPlaceCard({ place }: SecondaryPlaceCardProps) {
       </div>
 
       <div className="mt-4 grid gap-4 lg:grid-cols-2">
-        <UploadField
+        <AssetSelectorField
           label="360° image"
-          description="Drag & drop an immersive panorama"
-          previewUrl={place.virtualtour}
-          onUpload={handleHeroUpload}
-          onRemove={() => update({ virtualtour: undefined })}
-          cta="Upload 360° media"
-          accept={{ 'image/*': [] }}
+          description="Select a panorama from the library"
+          type="panorama"
+          value={place.virtualtour}
+          backend={backend}
+          onChange={handleHeroAsset}
         />
-        <UploadField
+        <AssetSelectorField
           label="Place logo"
           description="Logos replace legacy 3D models"
-          previewUrl={place.logoUrl}
-          onUpload={handleLogoUpload}
-          onRemove={() => update({ logoUrl: undefined })}
-          cta="Upload logo"
-          accept={{ 'image/*': [] }}
-          borderlessPreview
+          type="logo"
+          value={place.logoUrl}
+          backend={backend}
+          onChange={handleLogoAsset}
         />
       </div>
 

--- a/map-platform-frontend/lib/assetLibraryStore.ts
+++ b/map-platform-frontend/lib/assetLibraryStore.ts
@@ -1,0 +1,128 @@
+'use client'
+
+import { create } from 'zustand'
+import type { AssetKind, LibraryAsset, PlaceTypeDefinition } from '@/types'
+import * as libraryApi from './libraryApi'
+
+interface AssetLibraryState {
+  logos: LibraryAsset[]
+  panoramas: LibraryAsset[]
+  placeTypes: PlaceTypeDefinition[]
+  loading: boolean
+  initialized: boolean
+  error?: string
+  fetchAll: (backend: string) => Promise<void>
+  createAsset: (
+    backend: string,
+    payload: { type: AssetKind; label: string; url: string; publicId?: string },
+  ) => Promise<LibraryAsset>
+  updateAsset: (
+    backend: string,
+    id: string,
+    payload: Partial<Pick<LibraryAsset, 'label' | 'url' | 'publicId'>>,
+  ) => Promise<LibraryAsset>
+  deleteAsset: (backend: string, id: string, type: AssetKind) => Promise<void>
+  createPlaceType: (
+    backend: string,
+    payload: { name: string; description?: string },
+  ) => Promise<PlaceTypeDefinition>
+  updatePlaceType: (
+    backend: string,
+    id: string,
+    payload: Partial<Pick<PlaceTypeDefinition, 'name' | 'description'>>,
+  ) => Promise<PlaceTypeDefinition>
+  deletePlaceType: (backend: string, id: string) => Promise<void>
+}
+
+function sortAssets(items: LibraryAsset[]): LibraryAsset[] {
+  return [...items].sort((a, b) => a.label.localeCompare(b.label))
+}
+
+function sortPlaceTypes(items: PlaceTypeDefinition[]): PlaceTypeDefinition[] {
+  return [...items].sort((a, b) => a.name.localeCompare(b.name))
+}
+
+export const useAssetLibrary = create<AssetLibraryState>((set, get) => ({
+  logos: [],
+  panoramas: [],
+  placeTypes: [],
+  loading: false,
+  initialized: false,
+  error: undefined,
+
+  fetchAll: async (backend) => {
+    const state = get()
+    if (state.loading) return
+    set({ loading: true, error: undefined })
+    try {
+      const [logos, panoramas, placeTypes] = await Promise.all([
+        libraryApi.fetchAssets(backend, 'logo'),
+        libraryApi.fetchAssets(backend, 'panorama'),
+        libraryApi.fetchPlaceTypes(backend),
+      ])
+      set({
+        logos: sortAssets(logos),
+        panoramas: sortAssets(panoramas),
+        placeTypes: sortPlaceTypes(placeTypes),
+        loading: false,
+        initialized: true,
+        error: undefined,
+      })
+    } catch (error) {
+      console.error('Failed to fetch asset library', error)
+      set({
+        loading: false,
+        initialized: true,
+        error: error instanceof Error ? error.message : 'Unable to load asset library',
+      })
+    }
+  },
+
+  createAsset: async (backend, payload) => {
+    const asset = await libraryApi.createAsset(backend, payload)
+    set((state) =>
+      payload.type === 'logo'
+        ? { logos: sortAssets([...state.logos.filter((item) => item._id !== asset._id), asset]) }
+        : { panoramas: sortAssets([...state.panoramas.filter((item) => item._id !== asset._id), asset]) },
+    )
+    return asset
+  },
+
+  updateAsset: async (backend, id, payload) => {
+    const asset = await libraryApi.updateAsset(backend, id, payload)
+    set((state) =>
+      asset.type === 'logo'
+        ? { logos: sortAssets(state.logos.map((item) => (item._id === asset._id ? asset : item))) }
+        : { panoramas: sortAssets(state.panoramas.map((item) => (item._id === asset._id ? asset : item))) },
+    )
+    return asset
+  },
+
+  deleteAsset: async (backend, id, type) => {
+    await libraryApi.deleteAsset(backend, id)
+    set((state) =>
+      type === 'logo'
+        ? { logos: state.logos.filter((item) => item._id !== id) }
+        : { panoramas: state.panoramas.filter((item) => item._id !== id) },
+    )
+  },
+
+  createPlaceType: async (backend, payload) => {
+    const item = await libraryApi.createPlaceType(backend, payload)
+    set((state) => ({ placeTypes: sortPlaceTypes([...state.placeTypes, item]) }))
+    return item
+  },
+
+  updatePlaceType: async (backend, id, payload) => {
+    const item = await libraryApi.updatePlaceType(backend, id, payload)
+    set((state) => ({
+      placeTypes: sortPlaceTypes(state.placeTypes.map((p) => (p._id === item._id ? item : p))),
+    }))
+    return item
+  },
+
+  deletePlaceType: async (backend, id) => {
+    await libraryApi.deletePlaceType(backend, id)
+    set((state) => ({ placeTypes: state.placeTypes.filter((p) => p._id !== id) }))
+  },
+}))

--- a/map-platform-frontend/lib/libraryApi.ts
+++ b/map-platform-frontend/lib/libraryApi.ts
@@ -1,0 +1,90 @@
+import type { AssetKind, LibraryAsset, PlaceTypeDefinition } from '@/types'
+
+function withBase(url: string, path: string): string {
+  return `${url.replace(/\/$/, '')}${path}`
+}
+
+async function parseJson<T>(res: Response): Promise<T> {
+  if (!res.ok) {
+    const text = await res.text()
+    throw new Error(text || `Request failed with status ${res.status}`)
+  }
+  return res.json() as Promise<T>
+}
+
+export async function fetchAssets(backend: string, type?: AssetKind): Promise<LibraryAsset[]> {
+  const search = type ? `?type=${encodeURIComponent(type)}` : ''
+  const res = await fetch(withBase(backend, `/api/assets${search}`))
+  const data = await parseJson<{ items: LibraryAsset[] }>(res)
+  return data.items
+}
+
+export async function createAsset(
+  backend: string,
+  payload: { type: AssetKind; label: string; url: string; publicId?: string },
+): Promise<LibraryAsset> {
+  const res = await fetch(withBase(backend, '/api/assets'), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
+  const data = await parseJson<{ item: LibraryAsset }>(res)
+  return data.item
+}
+
+export async function updateAsset(
+  backend: string,
+  id: string,
+  payload: Partial<Pick<LibraryAsset, 'label' | 'url' | 'publicId'>>,
+): Promise<LibraryAsset> {
+  const res = await fetch(withBase(backend, `/api/assets/${id}`), {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
+  const data = await parseJson<{ item: LibraryAsset }>(res)
+  return data.item
+}
+
+export async function deleteAsset(backend: string, id: string): Promise<void> {
+  const res = await fetch(withBase(backend, `/api/assets/${id}`), { method: 'DELETE' })
+  await parseJson<{ ok: boolean }>(res)
+}
+
+export async function fetchPlaceTypes(backend: string): Promise<PlaceTypeDefinition[]> {
+  const res = await fetch(withBase(backend, '/api/place-types'))
+  const data = await parseJson<{ items: PlaceTypeDefinition[] }>(res)
+  return data.items
+}
+
+export async function createPlaceType(
+  backend: string,
+  payload: { name: string; description?: string },
+): Promise<PlaceTypeDefinition> {
+  const res = await fetch(withBase(backend, '/api/place-types'), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
+  const data = await parseJson<{ item: PlaceTypeDefinition }>(res)
+  return data.item
+}
+
+export async function updatePlaceType(
+  backend: string,
+  id: string,
+  payload: Partial<Pick<PlaceTypeDefinition, 'name' | 'description'>>,
+): Promise<PlaceTypeDefinition> {
+  const res = await fetch(withBase(backend, `/api/place-types/${id}`), {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
+  const data = await parseJson<{ item: PlaceTypeDefinition }>(res)
+  return data.item
+}
+
+export async function deletePlaceType(backend: string, id: string): Promise<void> {
+  const res = await fetch(withBase(backend, `/api/place-types/${id}`), { method: 'DELETE' })
+  await parseJson<{ ok: boolean }>(res)
+}

--- a/map-platform-frontend/types/index.ts
+++ b/map-platform-frontend/types/index.ts
@@ -61,6 +61,28 @@ export interface UploadResponse {
   height?: number
 }
 
+export type AssetKind = 'logo' | 'panorama'
+
+export interface LibraryAsset {
+  _id: string
+  id?: string
+  type: AssetKind
+  label: string
+  url: string
+  publicId?: string
+  createdAt?: string
+  updatedAt?: string
+}
+
+export interface PlaceTypeDefinition {
+  _id: string
+  id?: string
+  name: string
+  description?: string
+  createdAt?: string
+  updatedAt?: string
+}
+
 export interface ExportOptions {
   includeSecondaries: boolean
   includeRoutes: boolean


### PR DESCRIPTION
## Summary
- add backend models, schemas, and routes for reusable image assets and place type definitions
- build a settings page with tooling to upload, rename, and delete Cloudinary-backed assets and place types
- integrate asset dropdowns across project forms so logos and panoramas are selected from the shared library

## Testing
- npm run lint *(fails: next not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6c016d0048324b179075334b8cfb1