### PR TITLE
Replace alerts with toast notifications

### DIFF
--- a/map-platform-frontend/app/layout.tsx
+++ b/map-platform-frontend/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
 import './globals.css'
-import 'maplibre-gl/dist/maplibre-gl.css'
+import { ToastProvider } from '@/components/providers/ToastProvider'
 
 const inter = Inter({ subsets: ['latin'] })
 
@@ -17,7 +17,10 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className={inter.className}>{children}</body>
+      <body className={inter.className}>
+        <ToastProvider />
+        {children}
+      </body>
     </html>
   )
-} 
+}

--- a/map-platform-frontend/app/page.tsx
+++ b/map-platform-frontend/app/page.tsx
@@ -12,6 +12,7 @@ import { useStudio } from '@/lib/studioStore'
 import { saveProject } from '@/lib/api'
 import type { ExportOptions } from '@/types'
 import { useAssetLibrary } from '@/lib/assetLibraryStore'
+import { toast } from '@/lib/toast'
 
 const DEFAULT_EXPORT: ExportOptions = {
   includeSecondaries: true,
@@ -47,7 +48,7 @@ export default function StudioPage() {
       const hasPano = Boolean(place.virtualtour)
       const hasTour = Boolean(place.tourUrl)
       if (hasPano === hasTour) {
-        alert(`Place "${place.name}" must include either a 360° image or a tour URL.`)
+        toast.warning(`Place "${place.name}" must include either a 360° image or a tour URL.`)
         return false
       }
     }
@@ -62,7 +63,7 @@ export default function StudioPage() {
       return saved
     } catch (error) {
       console.error(error)
-      alert('Unable to save the project. Please try again.')
+      toast.error('Unable to save the project. Please try again.')
       throw error
     } finally {
       setSaving(false)
@@ -108,7 +109,7 @@ export default function StudioPage() {
       setExportOpen(false)
     } catch (error) {
       console.error(error)
-      alert('Unable to export the project. Please verify the backend service.')
+      toast.error('Unable to export the project. Please verify the backend service.')
     } finally {
       setExporting(false)
     }

--- a/map-platform-frontend/app/settings/page.tsx
+++ b/map-platform-frontend/app/settings/page.tsx
@@ -7,6 +7,7 @@ import { useStudio } from '@/lib/studioStore'
 import { useAssetLibrary } from '@/lib/assetLibraryStore'
 import { uploadImage } from '@/lib/api'
 import type { AssetKind, LibraryAsset, PlaceTypeDefinition } from '@/types'
+import { toast } from '@/lib/toast'
 
 function useLibraryBootstrap(backend: string) {
   const fetchLibrary = useAssetLibrary((state) => state.fetchAll)
@@ -40,12 +41,12 @@ function AssetManagerSection({ title, description, type, backend }: AssetManager
 
   const handleUpload = useCallback(async () => {
     if (!file) {
-      alert('Select a file to upload.')
+      toast.warning('Select a file to upload.')
       return
     }
     const trimmedLabel = label.trim()
     if (!trimmedLabel) {
-      alert('Provide a label for this asset.')
+      toast.info('Provide a label for this asset.')
       return
     }
     setUploading(true)
@@ -59,9 +60,10 @@ function AssetManagerSection({ title, description, type, backend }: AssetManager
       })
       setLabel('')
       setFile(null)
+      toast.success('Asset uploaded to the library.')
     } catch (error) {
       console.error('Unable to create asset', error)
-      alert('Upload failed. Please try again or check your backend configuration.')
+      toast.error('Upload failed. Please try again or check your backend configuration.')
     } finally {
       setUploading(false)
     }
@@ -75,9 +77,10 @@ function AssetManagerSection({ title, description, type, backend }: AssetManager
       if (!trimmed || trimmed === asset.label) return
       try {
         await updateAsset(backend, asset._id, { label: trimmed })
+        toast.success('Asset renamed successfully.')
       } catch (error) {
         console.error('Rename failed', error)
-        alert('Unable to rename asset. Please try again.')
+        toast.error('Unable to rename asset. Please try again.')
       }
     },
     [backend, updateAsset],
@@ -88,9 +91,10 @@ function AssetManagerSection({ title, description, type, backend }: AssetManager
       if (!window.confirm(`Delete asset "${asset.label}"?`)) return
       try {
         await deleteAsset(backend, asset._id, type)
+        toast.success('Asset deleted.')
       } catch (error) {
         console.error('Delete failed', error)
-        alert('Unable to delete asset. Please try again.')
+        toast.error('Unable to delete asset. Please try again.')
       }
     },
     [backend, deleteAsset, type],
@@ -197,7 +201,7 @@ function PlaceTypeManagerSection({ backend }: PlaceTypeManagerSectionProps) {
   const handleCreate = useCallback(async () => {
     const trimmed = name.trim()
     if (!trimmed) {
-      alert('Provide a name for the place type.')
+      toast.info('Provide a name for the place type.')
       return
     }
     setSaving(true)
@@ -205,9 +209,10 @@ function PlaceTypeManagerSection({ backend }: PlaceTypeManagerSectionProps) {
       await createPlaceType(backend, { name: trimmed, description: description.trim() || undefined })
       setName('')
       setDescription('')
+      toast.success('Place type created.')
     } catch (error) {
       console.error('Unable to create place type', error)
-      alert('Creation failed. Please try again.')
+      toast.error('Creation failed. Please try again.')
     } finally {
       setSaving(false)
     }
@@ -221,9 +226,10 @@ function PlaceTypeManagerSection({ backend }: PlaceTypeManagerSectionProps) {
       if (!trimmed || trimmed === type.name) return
       try {
         await updatePlaceType(backend, type._id, { name: trimmed })
+        toast.success('Place type renamed.')
       } catch (error) {
         console.error('Rename failed', error)
-        alert('Unable to rename place type. Please try again.')
+        toast.error('Unable to rename place type. Please try again.')
       }
     },
     [backend, updatePlaceType],
@@ -236,9 +242,10 @@ function PlaceTypeManagerSection({ backend }: PlaceTypeManagerSectionProps) {
       const trimmed = next.trim()
       try {
         await updatePlaceType(backend, type._id, { description: trimmed || undefined })
+        toast.success('Description updated.')
       } catch (error) {
         console.error('Update failed', error)
-        alert('Unable to update description. Please try again.')
+        toast.error('Unable to update description. Please try again.')
       }
     },
     [backend, updatePlaceType],
@@ -249,9 +256,10 @@ function PlaceTypeManagerSection({ backend }: PlaceTypeManagerSectionProps) {
       if (!window.confirm(`Delete place type "${type.name}"?`)) return
       try {
         await deletePlaceType(backend, type._id)
+        toast.success('Place type deleted.')
       } catch (error) {
         console.error('Delete failed', error)
-        alert('Unable to delete place type. Please try again.')
+        toast.error('Unable to delete place type. Please try again.')
       }
     },
     [backend, deletePlaceType],

--- a/map-platform-frontend/components/library/AssetSelectorField.tsx
+++ b/map-platform-frontend/components/library/AssetSelectorField.tsx
@@ -6,6 +6,7 @@ import { ImageIcon, Loader2, PlusCircle, XCircle } from 'lucide-react'
 import { uploadImage } from '@/lib/api'
 import { useAssetLibrary } from '@/lib/assetLibraryStore'
 import type { AssetKind, LibraryAsset } from '@/types'
+import { toast } from '@/lib/toast'
 
 interface AssetSelectorFieldProps {
   label: string
@@ -62,12 +63,12 @@ export function AssetSelectorField({ label, description, type, value, backend, o
 
   const handleUpload = useCallback(async () => {
     if (!selectedFile) {
-      alert('Select an image to upload.')
+      toast.warning('Select an image to upload.')
       return
     }
     const trimmedLabel = newLabel.trim()
     if (!trimmedLabel) {
-      alert('Provide a label for this asset before uploading.')
+      toast.info('Provide a label for this asset before uploading.')
       return
     }
     setUploading(true)
@@ -81,9 +82,10 @@ export function AssetSelectorField({ label, description, type, value, backend, o
       })
       onChange(asset)
       resetUploader()
+      toast.success('Asset uploaded to your library.')
     } catch (error) {
       console.error('Asset upload failed', error)
-      alert('Unable to upload the asset. Please try again.')
+      toast.error('Unable to upload the asset. Please try again.')
     } finally {
       setUploading(false)
     }

--- a/map-platform-frontend/components/project/SecondaryPlaceCard.tsx
+++ b/map-platform-frontend/components/project/SecondaryPlaceCard.tsx
@@ -9,6 +9,7 @@ import type { LibraryAsset, Place } from '@/types'
 import { AssetSelectorField } from '@/components/library/AssetSelectorField'
 import { PlaceTypeSelectField } from '@/components/library/PlaceTypeSelectField'
 import { MediaPreview } from './MediaPreview'
+import { toast } from '@/lib/toast'
 
 interface SecondaryPlaceCardProps {
   place: Place
@@ -75,7 +76,7 @@ export function SecondaryPlaceCard({ place }: SecondaryPlaceCardProps) {
       })
     } catch (error) {
       console.error('Routing failed', error)
-      alert('Unable to compute route. Please try again later.')
+      toast.error('Unable to compute route. Please try again later.')
     } finally {
       setIsRouting(false)
     }

--- a/map-platform-frontend/components/providers/ToastProvider.tsx
+++ b/map-platform-frontend/components/providers/ToastProvider.tsx
@@ -1,0 +1,119 @@
+'use client'
+
+import { createPortal } from 'react-dom'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { X } from 'lucide-react'
+import { toast, toastEmitter, TOAST_ADD_EVENT, TOAST_DISMISS_EVENT, type ToastDetail, type ToastVariant } from '@/lib/toast'
+
+const VARIANT_STYLES: Record<ToastVariant, string> = {
+  info: 'bg-sky-600 text-white',
+  success: 'bg-emerald-600 text-white',
+  warning: 'bg-amber-400 text-navy-900',
+  error: 'bg-rose-600 text-white',
+}
+
+const CLOSE_BUTTON_STYLES: Record<ToastVariant, string> = {
+  info: 'text-white hover:bg-white/20',
+  success: 'text-white hover:bg-white/20',
+  warning: 'text-navy-900 hover:bg-black/10',
+  error: 'text-white hover:bg-white/20',
+}
+
+const CLOSE_BUTTON_BACKGROUND: Record<ToastVariant, string> = {
+  info: 'bg-white/10',
+  success: 'bg-white/10',
+  warning: 'bg-black/5',
+  error: 'bg-white/10',
+}
+
+export function ToastProvider() {
+  const [mounted, setMounted] = useState(false)
+  const [toasts, setToasts] = useState<ToastDetail[]>([])
+  const timeouts = useRef<Map<number, number>>(new Map())
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  const clearTimeoutFor = useCallback((id: number) => {
+    const timeoutId = timeouts.current.get(id)
+    if (timeoutId) {
+      window.clearTimeout(timeoutId)
+      timeouts.current.delete(id)
+    }
+  }, [])
+
+  useEffect(() => {
+    const handleAdd = (event: Event) => {
+      const detail = (event as CustomEvent<ToastDetail>).detail
+      setToasts((prev) => {
+        const next = [...prev, detail]
+        if (next.length > 4) {
+          const [removed, ...rest] = next
+          clearTimeoutFor(removed.id)
+          return rest
+        }
+        return next
+      })
+      const timeoutId = window.setTimeout(() => {
+        toast.dismiss(detail.id)
+      }, detail.duration)
+      timeouts.current.set(detail.id, timeoutId)
+    }
+
+    const handleDismiss = (event: Event) => {
+      const id = (event as CustomEvent<number | undefined>).detail
+      setToasts((prev) => {
+        if (typeof id === 'number') {
+          return prev.filter((item) => item.id !== id)
+        }
+        return []
+      })
+      if (typeof id === 'number') {
+        clearTimeoutFor(id)
+      } else {
+        timeouts.current.forEach((timeoutId) => window.clearTimeout(timeoutId))
+        timeouts.current.clear()
+      }
+    }
+
+    toastEmitter.addEventListener(TOAST_ADD_EVENT, handleAdd as EventListener)
+    toastEmitter.addEventListener(TOAST_DISMISS_EVENT, handleDismiss as EventListener)
+
+    return () => {
+      toastEmitter.removeEventListener(TOAST_ADD_EVENT, handleAdd as EventListener)
+      toastEmitter.removeEventListener(TOAST_DISMISS_EVENT, handleDismiss as EventListener)
+      timeouts.current.forEach((timeoutId) => window.clearTimeout(timeoutId))
+      timeouts.current.clear()
+    }
+  }, [clearTimeoutFor])
+
+  const portalContent = useMemo(() => {
+    if (!mounted) return null
+
+    return createPortal(
+      <div className="pointer-events-none fixed inset-x-0 top-0 z-50 flex flex-col items-end gap-3 p-4 sm:items-end sm:p-6">
+        {toasts.map((item) => (
+          <div
+            key={item.id}
+            className={`pointer-events-auto flex min-w-[260px] max-w-sm items-start gap-3 rounded-2xl px-4 py-3 shadow-xl ring-1 ring-black/10 ${VARIANT_STYLES[item.variant]} transition`}
+            role={item.variant === 'error' || item.variant === 'warning' ? 'alert' : 'status'}
+            aria-live={item.variant === 'error' || item.variant === 'warning' ? 'assertive' : 'polite'}
+          >
+            <div className="flex-1 text-sm font-medium leading-snug">{item.message}</div>
+            <button
+              type="button"
+              onClick={() => toast.dismiss(item.id)}
+              className={`rounded-full p-1 transition ${CLOSE_BUTTON_BACKGROUND[item.variant]} ${CLOSE_BUTTON_STYLES[item.variant]}`}
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+        ))}
+      </div>,
+      document.body,
+    )
+  }, [mounted, toasts])
+
+  return portalContent
+}

--- a/map-platform-frontend/lib/toast.ts
+++ b/map-platform-frontend/lib/toast.ts
@@ -1,0 +1,57 @@
+'use client'
+
+type ToastVariant = 'info' | 'success' | 'warning' | 'error'
+
+export interface ToastDetail {
+  id: number
+  message: string
+  variant: ToastVariant
+  duration: number
+}
+
+export interface ToastOptions {
+  duration?: number
+}
+
+const TOAST_ADD_EVENT = 'toast:add'
+const TOAST_DISMISS_EVENT = 'toast:dismiss'
+
+const toastEmitter = new EventTarget()
+
+let toastId = 0
+const DEFAULT_DURATION = 4000
+
+function dispatchToast(variant: ToastVariant, message: string, options?: ToastOptions) {
+  toastId += 1
+  const detail: ToastDetail = {
+    id: toastId,
+    message,
+    variant,
+    duration: options?.duration ?? DEFAULT_DURATION,
+  }
+
+  toastEmitter.dispatchEvent(new CustomEvent<ToastDetail>(TOAST_ADD_EVENT, { detail }))
+  return detail.id
+}
+
+export const toast = {
+  info(message: string, options?: ToastOptions) {
+    return dispatchToast('info', message, options)
+  },
+  success(message: string, options?: ToastOptions) {
+    return dispatchToast('success', message, options)
+  },
+  warning(message: string, options?: ToastOptions) {
+    return dispatchToast('warning', message, options)
+  },
+  error(message: string, options?: ToastOptions) {
+    return dispatchToast('error', message, options)
+  },
+  dismiss(id?: number) {
+    toastEmitter.dispatchEvent(new CustomEvent<number | undefined>(TOAST_DISMISS_EVENT, { detail: id }))
+  },
+}
+
+export { toastEmitter, TOAST_ADD_EVENT, TOAST_DISMISS_EVENT }
+
+export type { ToastVariant }


### PR DESCRIPTION
## Summary
- add a reusable toast provider and helper to surface notification events across the app
- swap blocking browser alerts for styled toast notifications in the studio, asset library, and place management flows

## Testing
- npm run lint *(fails: Next CLI is not available in the environment yet)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d36113e4832495c584d08c01f53b