### PR TITLE
Add saved project selector to studio page

### DIFF
--- a/map-platform-frontend/app/page.tsx
+++ b/map-platform-frontend/app/page.tsx
@@ -2,15 +2,15 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { motion } from 'framer-motion'
-import { Download, Loader2, Save } from 'lucide-react'
+import { Download, Loader2, RefreshCw, Save } from 'lucide-react'
 import { ProjectHero } from '@/components/project/ProjectHero'
 import { PrincipalPlaceForm } from '@/components/project/PrincipalPlaceForm'
 import { SecondaryPlacesPanel } from '@/components/project/SecondaryPlacesPanel'
 import { StudioMap } from '@/components/Map/StudioMap'
 import { ExportProjectDialog } from '@/components/project/ExportProjectDialog'
 import { useStudio } from '@/lib/studioStore'
-import { saveProject } from '@/lib/api'
-import type { ExportOptions } from '@/types'
+import { fetchProjectById, fetchProjectSummaries, saveProject } from '@/lib/api'
+import type { ExportOptions, ProjectSummary } from '@/types'
 import { useAssetLibrary } from '@/lib/assetLibraryStore'
 import { toast } from '@/lib/toast'
 
@@ -21,10 +21,11 @@ const DEFAULT_EXPORT: ExportOptions = {
 }
 
 export default function StudioPage() {
-  const { project, setProject, backend } = useStudio((state) => ({
+  const { project, setProject, backend, resetProject } = useStudio((state) => ({
     project: state.project,
     setProject: state.setProject,
     backend: state.backend,
+    resetProject: state.resetProject,
   }))
 
   const fetchLibrary = useAssetLibrary((state) => state.fetchAll)
@@ -34,6 +35,10 @@ export default function StudioPage() {
   const [exporting, setExporting] = useState(false)
   const [exportOpen, setExportOpen] = useState(false)
   const [options, setOptions] = useState<ExportOptions>(DEFAULT_EXPORT)
+  const [projects, setProjects] = useState<ProjectSummary[]>([])
+  const [projectsLoading, setProjectsLoading] = useState(false)
+  const [projectLoading, setProjectLoading] = useState(false)
+  const [selectedProjectId, setSelectedProjectId] = useState('')
 
   const allPlaces = useMemo(() => [project.principal, ...project.secondaries], [project])
 
@@ -42,6 +47,50 @@ export default function StudioPage() {
       fetchLibrary(backend)
     }
   }, [backend, fetchLibrary, libraryLoaded])
+
+  useEffect(() => {
+    setSelectedProjectId(project._id ?? '')
+  }, [project._id])
+
+  const loadProjects = useCallback(async () => {
+    setProjectsLoading(true)
+    try {
+      const items = await fetchProjectSummaries(backend)
+      setProjects(items)
+    } catch (error) {
+      console.error(error)
+      toast.error('Unable to load saved projects. Please verify the backend service.')
+    } finally {
+      setProjectsLoading(false)
+    }
+  }, [backend])
+
+  useEffect(() => {
+    void loadProjects()
+  }, [loadProjects])
+
+  const handleSelectProject = useCallback(
+    async (id: string) => {
+      setSelectedProjectId(id)
+      if (!id) {
+        resetProject()
+        return
+      }
+
+      setProjectLoading(true)
+      try {
+        const loaded = await fetchProjectById(id, backend)
+        setProject(loaded)
+        toast.success('Project loaded.')
+      } catch (error) {
+        console.error(error)
+        toast.error('Unable to load the selected project.')
+      } finally {
+        setProjectLoading(false)
+      }
+    },
+    [backend, resetProject, setProject],
+  )
 
   const ensureMediaIsValid = useCallback(() => {
     for (const place of allPlaces) {
@@ -72,7 +121,8 @@ export default function StudioPage() {
 
   const handleSave = useCallback(async () => {
     await ensureProjectSaved()
-  }, [ensureProjectSaved])
+    await loadProjects()
+  }, [ensureProjectSaved, loadProjects])
 
   const handleExport = useCallback(async () => {
     if (!ensureMediaIsValid()) return
@@ -80,6 +130,9 @@ export default function StudioPage() {
     setExporting(true)
     try {
       const saved = project._id ? project : await ensureProjectSaved()
+      if (!project._id) {
+        await loadProjects()
+      }
       const payload = {
         inlineAssets: options.includeImages,
         inlineData: options.includeImages,
@@ -125,6 +178,42 @@ export default function StudioPage() {
               <p className="text-sm text-navy-600">Design elegant tours powered by accessible Radix UI components and delightful motion.</p>
             </div>
             <div className="flex flex-wrap items-center gap-3">
+              <div className="flex flex-col gap-1 text-xs text-navy-600">
+                <span className="font-semibold uppercase tracking-wide text-navy-700">Saved projects</span>
+                <div className="flex items-center gap-2">
+                  <select
+                    value={selectedProjectId}
+                    onChange={(event) => {
+                      const value = event.target.value
+                      void handleSelectProject(value)
+                    }}
+                    disabled={projectsLoading || projectLoading}
+                    className="min-w-[12rem] rounded-xl border border-navy-200 px-3 py-1.5 text-sm text-navy-900 shadow-inner focus:border-gold-400 focus:outline-none disabled:cursor-not-allowed disabled:opacity-70"
+                  >
+                    <option value="">New project…</option>
+                    {projects.map((item) => (
+                      <option key={item._id} value={item._id}>
+                        {item.title || 'Untitled project'}
+                      </option>
+                    ))}
+                  </select>
+                  <button
+                    type="button"
+                    onClick={() => void loadProjects()}
+                    disabled={projectsLoading}
+                    className="inline-flex items-center gap-2 rounded-full border border-navy-200 px-3 py-1.5 text-xs font-semibold text-navy-700 transition hover:border-gold-400 hover:text-gold-600 disabled:cursor-not-allowed disabled:opacity-70"
+                    title="Refresh project list"
+                  >
+                    {projectsLoading ? (
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                      <RefreshCw className="h-3.5 w-3.5" />
+                    )}
+                    Refresh
+                  </button>
+                  {projectLoading ? <Loader2 className="h-4 w-4 animate-spin text-navy-600" aria-label="Loading project" /> : null}
+                </div>
+              </div>
               <button
                 type="button"
                 onClick={handleSave}

--- a/map-platform-frontend/lib/api.ts
+++ b/map-platform-frontend/lib/api.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import type { Feature, LineString } from 'geojson'
-import type { Place, Project, UploadResponse } from '@/types'
+import type { Place, Project, ProjectSummary, UploadResponse } from '@/types'
 import { formatHhMm, formatKm, getRoute } from './osrm'
 
 export function prettyLatLng(lat: number, lng: number): string {
@@ -59,10 +59,13 @@ export function sanitizeProject(project: Project): Project {
 
 export async function saveProject(project: Project, backend: string): Promise<Project> {
   const payload = sanitizeProject(project)
+  const hasId = Boolean(project._id)
+  const endpoint = hasId ? `${backend}/api/projects/${project._id}` : `${backend}/api/projects`
+  const method = hasId ? 'PUT' : 'POST'
 
   try {
-    const res = await fetch(`${backend}/api/projects`, {
-      method: 'POST',
+    const res = await fetch(endpoint, {
+      method,
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     })
@@ -74,7 +77,7 @@ export async function saveProject(project: Project, backend: string): Promise<Pr
     return res.json()
   } catch (error) {
     console.warn('Falling back to mock project save', error)
-    const mockId = `mock-${Date.now()}`
+    const mockId = project._id || `mock-${Date.now()}`
     return {
       ...project,
       _id: mockId,
@@ -82,9 +85,40 @@ export async function saveProject(project: Project, backend: string): Promise<Pr
         ...place,
         _id: place._id || `place-${mockId}-${index}`,
       })),
-      createdAt: new Date().toISOString(),
+      createdAt: project.createdAt ?? new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     }
+  }
+}
+
+export async function fetchProjectSummaries(backend: string): Promise<ProjectSummary[]> {
+  try {
+    const res = await fetch(`${backend}/api/projects`)
+    if (!res.ok) {
+      throw new Error(`List failed: ${res.status}`)
+    }
+    const items: ProjectSummary[] = await res.json()
+    return items
+  } catch (error) {
+    console.error('Unable to fetch project list', error)
+    throw error
+  }
+}
+
+export async function fetchProjectById(id: string, backend: string): Promise<Project> {
+  try {
+    const res = await fetch(`${backend}/api/projects/${id}`)
+    if (!res.ok) {
+      throw new Error(`Fetch project failed: ${res.status}`)
+    }
+    const project: Project = await res.json()
+    return {
+      ...project,
+      secondaries: project.secondaries ?? [],
+    }
+  } catch (error) {
+    console.error('Unable to fetch project data', error)
+    throw error
   }
 }
 

--- a/map-platform-frontend/lib/studioStore.ts
+++ b/map-platform-frontend/lib/studioStore.ts
@@ -24,6 +24,17 @@ const defaultProject: Project = {
   secondaries: [],
 }
 
+export function createDefaultProject(): Project {
+  return {
+    ...defaultProject,
+    principal: {
+      ...defaultProject.principal,
+      footerInfo: { ...defaultProject.principal.footerInfo },
+    },
+    secondaries: [],
+  }
+}
+
 export type StudioState = {
   backend: string
   project: Project
@@ -42,6 +53,7 @@ export type StudioState = {
   setMapInstance: (map: import('maplibre-gl').Map | null) => void
   setHoveredPlace: (id: string | null) => void
   setSelectedPlace: (id: string | null) => void
+  resetProject: () => void
 }
 
 function withId(place: Place | Partial<Place>): Place {
@@ -75,7 +87,7 @@ function withId(place: Place | Partial<Place>): Place {
 
 export const useStudio = create<StudioState>((set, get) => ({
   backend: process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:4000',
-  project: defaultProject,
+  project: createDefaultProject(),
   mapLib: null,
   mapInstance: null,
   hoveredPlaceId: null,
@@ -113,4 +125,5 @@ export const useStudio = create<StudioState>((set, get) => ({
   setMapInstance: (map) => set({ mapInstance: map }),
   setHoveredPlace: (id) => set({ hoveredPlaceId: id }),
   setSelectedPlace: (id) => set({ selectedPlaceId: id }),
+  resetProject: () => set({ project: createDefaultProject() }),
 }))

--- a/map-platform-frontend/types/index.ts
+++ b/map-platform-frontend/types/index.ts
@@ -53,6 +53,13 @@ export interface Project {
   updatedAt?: string
 }
 
+export interface ProjectSummary {
+  _id: string
+  title: string
+  createdAt?: string
+  updatedAt?: string
+}
+
 export interface UploadResponse {
   url: string
   public_id: string


### PR DESCRIPTION
## Summary
- add a saved project selector to the studio header that fetches projects from the backend
- allow loading an existing project or resetting to a new project for editing
- update project persistence helpers to support fetching summaries and updating existing records

## Testing
- npm run lint *(fails: next not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6dd59f1b483248e6b885ddf358db6